### PR TITLE
Mark docs as "internal"

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -5,7 +5,7 @@ host: reliability-engineering.cloudapps.digital
 show_govuk_logo: false
 service_name: Reliability Engineering
 service_link: https://reliability-engineering.cloudapps.digital
-phase: Alpha
+phase: Internal
 
 # Links to show on right-hand-side of header
 header_links:


### PR DESCRIPTION
This changes the current "alpha" badge to say "internal", similar to our
RE team manual and the GOV.UK team manual.  It's probably helpful to
have a thing that draws attention to the fact that these docs are not
for general public or cross-government guidance.

We do already have the page header which says:

> This documentation is intended for internal use by the GDS community.

but the banner is a bit more eye-catching.