### PR TITLE
Explain why we provide client libraries for prometheus

### DIFF
--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -45,7 +45,7 @@ We provide client libraries which wrap Prometheus's own libraries.  We do this f
 
 - to provide a sensible default choice
 - to provide a consistent set of metrics across with consistent naming across different runtimes
-- to solve problems like "how do you get metrics from individual worker processes?"
+- to solve problems like "how do you get metrics from all worker processes rather than just one?"
 - for GOV.UK PaaS apps, to guard the `/metrics` API behind http basic auth
 - to ease configuration through the use of framework-specific things like railties or dropwizard bundles.
 

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -41,6 +41,14 @@ We provide [ELK (Elasticsearch, Logstash, and Kibana)](https://www.elastic.co/el
 
 Reliability Engineering is running an Alpha on using [Prometheus](https://prometheus.io/) as the operational metrics service for GDS.
 
+We provide client libraries which wrap Prometheus's own libraries.  We do this for several reasons:
+
+- to provide a sensible default choice
+- to provide a consistent set of metrics across with consistent naming across different runtimes
+- to solve problems like "how do you get metrics from individual worker processes?"
+- for GOV.UK PaaS apps, to guard the `/metrics` API behind http basic auth
+- to ease configuration through the use of framework-specific things like railties or dropwizard bundles.
+
 You can setup GDS metrics with:
 
 - [Ruby](https://github.com/alphagov/gds_metrics_ruby)

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -4,8 +4,6 @@ title: Reliability Engineering
 
 # <%= current_page.data.title %>
 
-<intro to reliability engineering>
-
 Reliability Engineering provide a shared platform to GDS teams with the tools needed to set up and maintain a service, we do this by:
 
 * acquiring tools and where appropriate administer them for GDS, for example [Logit](https://logit.io/)

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -43,7 +43,7 @@ Reliability Engineering is running an Alpha on using [Prometheus](https://promet
 
 You can setup GDS metrics with:
 
-- [Ruby Rails](https://github.com/alphagov/gds_metrics_ruby)
+- [Ruby](https://github.com/alphagov/gds_metrics_ruby)
 - [Java with Dropwizard](https://github.com/alphagov/gds_metrics_dropwizard)
 
 When you use GDS metrics you can create:


### PR DESCRIPTION
We don't explain to people why you might want to use our client libraries instead of prometheus's official ones.  This PR adds a few reasons.