### PR TITLE
Add starter-for-ten process for managing paas org

### DIFF
--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -62,3 +62,9 @@ When you use GDS metrics you can create:
 Please <a href="mailto:the-gds-way@digital.cabinet-office.gov.uk?subject=feedback">contact us</a> to find out more.
 
 GDS Metrics is in alpha. These instructions are subject to change.
+
+## Internal docs
+
+This section is for members of the Reliability Engineering team.  We have internal guides on:
+
+- [how to manage our shared PaaS organisation](internal/paas.html)

--- a/source/internal/paas.html.md.erb
+++ b/source/internal/paas.html.md.erb
@@ -1,0 +1,32 @@
+---
+title: How to manage our internal PaaS organisation
+---
+
+# <%= current_page.data.title %>
+
+Reliability engineering uses the GOV.UK PaaS organisation `gds-tech-ops`.
+
+## Managing users
+
+All tech leads and technical architects in RE should be OrgManagers.  This means that your tech lead or technical architect should be able to add you to the PaaS organisation.  They should follow the [GOV.UK PaaS docs on adding users][].
+
+## Managing spaces and quotas
+
+We have an overall quota for the organisation.  You can see the name of the quota we're on by running `cf org gds-tech-ops` and see the details of the quota with `cf quota $NAME` -- for example, `cf quota small`.
+
+If one team uses up the organisation quota, it stops other teams from being able to create apps.  Therefore, teams should ensure they work in spaces, and that each space has a space quota.  If a team hits the quota for their space, it won't block other teams.  This is particularly problematic with memory usage.
+
+To create a space with a name of `log-pipeline` memory quota of 1 Gb, an OrgManager can run the following commands:
+
+- `cf create-space-quota log-pipeline -m 1g`
+- `cf create-space log-pipeline -o gds-tech-ops -q log-pipeline`
+
+To update the quota later, an OrgManager can run:
+
+- `cf update-space-quota $NAME -m 2g` where `2g` is the new memory quota value
+
+The command line accepts different units, such as `256m`, `512m`, `1g`, `5g`.
+
+It's okay for a space and a space quota to have the same name as each other.
+
+[GOV.UK PaaS docs on adding users]: https://docs.cloud.service.gov.uk/#adding-users

--- a/source/internal/paas.html.md.erb
+++ b/source/internal/paas.html.md.erb
@@ -29,4 +29,6 @@ The command line accepts different units, such as `256m`, `512m`, `1g`, `5g`.
 
 It's okay for a space and a space quota to have the same name as each other.
 
+To list the existing space quotas for an organisation, run `cf space-quotas`.
+
 [GOV.UK PaaS docs on adding users]: https://docs.cloud.service.gov.uk/#adding-users


### PR DESCRIPTION
We've had some issues recently with our shared PaaS org around user
management and memory quotas.  This adds some documentation to
describe some processes in these areas.

I'm not sure that this is the best place for the docs to live, but we
don't currently have an obvious home for RE-wide internal
documentation.