### PR TITLE
Edit - Platforms section of landing page

### DIFF
--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -16,7 +16,7 @@ To understand the context for our decisions and guidance you'll need to refer to
 
 Reliability Engineering develops, maintains and supports the [Amazon Web Services (AWS)][] and the [GOV.UK PaaS][] infrastructure GDS uses. GDS teams are responsible for the applications and components running on these platforms.
 
-For example, Reliability Engineering is responsible for rotating the SSL certificates that manage communications between AWS environments and [OpenVMS][]. GDS teams are responsible for rotating certificates that encrypt messages used by their service.
+For example, Reliability Engineering is responsible for managing the SSL certificates that handle communications between AWS environments and virtual machines. GDS teams are responsible for managing certificates that protect messages used by their service.
 
 ### Monitoring
 


### PR DESCRIPTION
Minor edits to 'Platforms' section of the landing page. Correcting use of OpenVMS and some phrasing.