### PR TITLE
fix links to paas tech docs

### DIFF
--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -63,7 +63,7 @@ These guides will help you:
 - [sign into Logit](manuals/logit-io-joiners.html)
 - [remove users from Logit](manuals/logit-io-leavers.html)
 - [send logs securely to Logit](manuals/logit-io.html)
-- [send logs from PaaS to logit](https://docs.cloud.service.gov.uk/#set-up-the-logit-io-log-management-service)
+- [send logs from PaaS to logit](https://docs.cloud.service.gov.uk/monitoring_apps.html#set-up-the-logit-io-log-management-service)
 - [respond to an incident with Logit](manuals/logit-incident-management.html)
 
 ### Metrics

--- a/source/manuals/grafana-dashboards.html.md.erb
+++ b/source/manuals/grafana-dashboards.html.md.erb
@@ -27,7 +27,7 @@ Select your application from the 'Available Apps' dropdown:
 
 ![Available Apps](images/available-apps.png)
 
-If you can't see your application in the list, make sure you've followed the instructions in [Setting up metrics](#setting-up-metrics) and that your changes have been deployed to the [GOV.UK PaaS](https://docs.cloud.service.gov.uk/#technical-documentation-for-gov-uk-paas).
+If you can't see your application in the list, make sure you've followed the instructions in [Setting up metrics](#setting-up-metrics) and that your changes have been deployed to the [GOV.UK PaaS](https://docs.cloud.service.gov.uk/).
 
 
 

--- a/source/manuals/monitor-paas-app-with-prometheus.html.md.erb
+++ b/source/manuals/monitor-paas-app-with-prometheus.html.md.erb
@@ -51,11 +51,11 @@ If there are no routes to your app the Prometheus service will default the route
 
 Because changes to the first route will only be picked up within 5 minutes it could create gaps to metrics during route changes if you're using a zero downtime plugin such as [autopilot][].
 
-[authorization header and other app headers]: https://docs.cloud.service.gov.uk/#forwarding-headers
+[authorization header and other app headers]: https://docs.cloud.service.gov.uk/deploying_services.html#forwarding-headers
 [autopilot]: https://github.com/contraband/autopilot
 [GOV.UK PaaS]: https://www.cloud.service.gov.uk/
 [Grafana]: https://grafana-paas.cloudapps.digital
 [Prometheus]: https://prometheus.io/
 [#re-prometheus-support Slack channel]: https://gds.slack.com/messages/CAF5H4N4Q/
-[`SpaceAuditor`]: https://docs.cloud.service.gov.uk/#user-roles-space-auditor
+[`SpaceAuditor`]: https://docs.cloud.service.gov.uk/orgs_spaces_users.html#space-auditor
 [update your app's manifest.yml]: https://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html#services-block

--- a/source/manuals/set-up-paas-metric-exporter-with-prometheus.html.md.erb
+++ b/source/manuals/set-up-paas-metric-exporter-with-prometheus.html.md.erb
@@ -26,7 +26,7 @@ Your new account should be separate to your primary Cloud Foundry account and us
 To set up the metrics exporter app:
 
 1. Clone the [paas-metric-exporter][] GitHub repository.
-2. [Push the metrics exporter app](https://docs.cloud.service.gov.uk/#deployment-overview) to Cloud Foundry (without starting the app) by running
+2. [Push the metrics exporter app](https://docs.cloud.service.gov.uk/deploying_apps.html) to Cloud Foundry (without starting the app) by running
  * `cf push -f manifest-prometheus.yml --no-start <app-name>`
 3. Set the following mandatory environment variables in the metrics exporter app using
   * `cf set-env <app-name> NAME VALUE`
@@ -74,10 +74,10 @@ If you're not receiving metrics, check the [logs][] for the metrics exporter app
 
 The Service Manual as more information about [monitoring the status of your service][].
 
-[Cloud Foundry account]: https://docs.cloud.service.gov.uk/#get-started
+[Cloud Foundry account]: https://docs.cloud.service.gov.uk/get_started.html
 [Cloud Foundry]: https://docs.cloudfoundry.org/concepts/overview.html
 [logs]: https://reliability-engineering.cloudapps.digital/#logging
 [monitoring the status of your service]: https://www.gov.uk/service-manual/technology/monitoring-the-status-of-your-service
 [paas-metric-exporter]: https://github.com/alphagov/paas-metric-exporter
 [#re-prometheus-support Slack channel]: https://gds.slack.com/messages/CAF5H4N4Q/
-[`SpaceAuditor`]: https://docs.cloud.service.gov.uk/#user-roles-space-auditor
+[`SpaceAuditor`]: https://docs.cloud.service.gov.uk/orgs_spaces_users.html#space-auditor


### PR DESCRIPTION
PaaS's tech docs have moved from a single-page to a multi-page
format.  This means our existing links based on URL fragments don't
work any more.

I grepped the whole repo for `cloud.service` to find links to the tech
docs and changed every link that needed changing.