### PR TITLE
Update TV instructions to use Chromebits

### DIFF
--- a/source/manuals/grafana-dashboards.html.md.erb
+++ b/source/manuals/grafana-dashboards.html.md.erb
@@ -90,9 +90,7 @@ Refer to the instructions below to help you orientate the Grafana interface:
 
 ## How to view dashboards on your team TV
 
-You can use your Google account to login and view Grafana dashboards, but if you want to display your dashboard on your team's TV, Reliability Enginering can provide your team with a view only acccount that is not linked to a Google account.
-
-You can request a view only user account through the [#reliability-eng Slack channel][].
+You can use your Google account to login and view Grafana dashboards, but if you want to display your dashboard on your team's TV you should not use your personal account as this may have editing or admin permissions. Instead you should use your TV's Google Chromebit user as this will be able to access Grafana but only have read permissions.
 
 ## More instructions for navigating Grafana
 


### PR DESCRIPTION
We believe now that all team TV's should have Chromebits attached
and this will mean no intervention is required from the Observe
team to get read only users set up.