### PR TITLE
Add creating and editing alerts documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ Type the following to start the server:
 bundle exec middleman server
 ```
 
+There is currently an [issue](https://github.com/alphagov/tech-docs-template/issues/149) in the `tech-docs-template gem` when running `middleman` locally which may cause the website to hang. To see the preview locally use this command:
+
+```
+EXECJS_RUNTIME=Node bundle exec middleman server
+```
+
 If all goes well something like the following output will be displayed:
 
 ```

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -66,7 +66,7 @@ These guides will help you:
 - [send logs from PaaS to logit](https://docs.cloud.service.gov.uk/monitoring_apps.html#set-up-the-logit-io-log-management-service)
 - [respond to an incident with Logit](manuals/logit-incident-management.html)
 
-### Metrics
+### Metrics and Alerting
 
 Reliability Engineering is running a beta service for GDS using [Prometheus](https://prometheus.io/) for operational metrics.
 
@@ -93,8 +93,9 @@ When using GDS metrics you can create:
 
 - [Grafana dashboards](manuals/grafana-dashboards.html)
 - [custom metrics](manuals/add-custom-metrics.html)
+- [alerts](manuals/alerting-with-prometheus-for-paas.html)
 
-Please email us at <a href="mailto:the-gds-way@digital.cabinet-office.gov.uk?subject=feedback">the-gds-way@digital.cabinet-office.gov.uk</a> to find out more.
+Please contact us on the [#re-prometheus-support][] Slack channel to find out more.
 
 GDS Metrics is currently in beta. These instructions are subject to change.
 
@@ -126,3 +127,4 @@ Reliability Engineering supports each GDS team's existing service levels until s
 [how to access AWS accounts]: manuals/access-aws-accounts.html
 [how to create AWS accounts]: manuals/create-aws-accounts.html
 [how AWS cross account access works]: manuals/aws-account-management.html
+[#re-prometheus-support]: https://gds.slack.com/messages/CAF5H4N4Q

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -127,4 +127,4 @@ Reliability Engineering supports each GDS team's existing service levels until s
 [how to access AWS accounts]: manuals/access-aws-accounts.html
 [how to create AWS accounts]: manuals/create-aws-accounts.html
 [how AWS cross account access works]: manuals/aws-account-management.html
-[#re-prometheus-support]: https://gds.slack.com/messages/CAF5H4N4Q
+[#re-prometheus-support]: https://gds.slack.com/messages/re-prometheus-support

--- a/source/manuals/alerting-with-prometheus-for-paas.html.md.erb
+++ b/source/manuals/alerting-with-prometheus-for-paas.html.md.erb
@@ -34,7 +34,7 @@ Alerting rules are defined in YAML format in a config file in the [prometheus-aw
 
 Alerting rules should be prefixed with your team name, e.g. `registers_RequestsExcess5xx`, `DGU_HighDiskUsage`, to make your alert easier to identify.
 
-Make sure that you add a `product` label to your alerting rule under `labels` so if it triggers the correct team is alerted.
+You must add a `product` label to your alerting rule under `labels` so if it triggers the correct team is alerted.
 
 An alerting rule file will look something like this:
 

--- a/source/manuals/alerting-with-prometheus-for-paas.html.md.erb
+++ b/source/manuals/alerting-with-prometheus-for-paas.html.md.erb
@@ -77,7 +77,7 @@ If you have not yet set up a receiver or would like to set up additional receive
 [4]: https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/
 [5]: https://prometheus.io/docs/prometheus/latest/querying/basics/
 [6]: https://gds-way.cloudapps.digital/standards/alerting.html#alerting
-[7]: https://gds.slack.com/messages/CAF5H4N4Q
+[7]: https://gds.slack.com/messages/re-prometheus-support
 [8]: https://github.com/alphagov/paas-metric-exporter
 [9]: https://github.com/alphagov/prometheus-aws-configuration-beta/blob/master/terraform/projects/app-ecs-services/templates/alertmanager.tpl
 [10]: https://prometheus.io/docs/alerting/alertmanager/

--- a/source/manuals/alerting-with-prometheus-for-paas.html.md.erb
+++ b/source/manuals/alerting-with-prometheus-for-paas.html.md.erb
@@ -22,7 +22,7 @@ You will also need to understand how to write an expression in [PromQL][5] for y
 
 Use the [Prometheus dashboard][1] to experiment writing your alert as a [PromQL][5] expression.
 
-Your expression must contain an `org` label, which refers to your PaaS organisation. This makes you sure it only uses metrics from your job. Although you can use the `job` label for this, it is not guaranteed to be unique to your team.
+Your expression must contain an `org` label, which refers to your PaaS organisation. This makes you sure it only uses metrics from your team. Although you can use the `job` label for this, it is not guaranteed to be unique to your team.
 
 You should only include timeseries for the PaaS space you wish to alert on, for example production. For timeseries produced by application client libraries, include `space="production"`. For timeseries produced by the [paas-metric-exporter][8] include `exported_space="production"`.
 

--- a/source/manuals/alerting-with-prometheus-for-paas.html.md.erb
+++ b/source/manuals/alerting-with-prometheus-for-paas.html.md.erb
@@ -1,0 +1,85 @@
+---
+title: How to create or edit alerts with Prometheus
+---
+
+# <%= current_page.data.title %>
+
+## What you should be alerting on
+
+When deciding on what your service should be alerting on, you could use the following:
+
+- [Alerting principles][6] in the GDS Way
+- Look at [existing alerting rules][2] used by other GDS teams
+- Talk to us for advice using the [#re-prometheus-support][7] Slack channel
+
+## How to create or update alerting rules
+
+You should first read the [Prometheus alerting rules documentation][4] to understand the alerting concepts.
+
+You will also need to understand how to write an expression in [PromQL][5] for your alerting rule.
+
+### Writing your alerting rule PromQL expression
+
+Use the [Prometheus dashboard][1] to experiment writing your alert as a [PromQL][5] expression.
+
+The expression should generate some metrics which could be used in the alert, so no metrics will mean that the alert will not fire.
+
+Your expression must contain a `job` label that points at your team's metrics so that you don't accidently include metrics from other teams.
+
+Make sure to only include timeseries for the PaaS space you wish to alert on (e.g. production). For timeseries produced by application client libraries, this can be done by including `space="production"`. For timeseries produced by the [paas-metric-exporter][8] this can be done by including `exported_space="production"`.
+
+### Create the alerting rule
+
+Alerting rules are defined in YAML format in a config file in the [prometheus-aws-configuration-beta][2] repository. Each product team should use their own file for their alerting rules.
+
+Alerting rules should be prefixed with your team name, e.g. `registers_RequestsExcess5xx`, `DGU_HighDiskUsage`, to make your alert easier to identify.
+
+Make sure that you add a `product` label to your alerting rule under `labels` so if it triggers the correct team is alerted.
+
+An alerting rule file will look something like this:
+
+```
+  groups:
+- name: Your team name
+  rules:
+  - alert: RequestsExcess5xx
+    expr: rate(requests{job="yourteam-metric-exporter", exported_space="prod", status_range="5xx"}[5m]) > 1
+    for: 120s
+    labels:
+        product: "yourteam"
+    annotations:
+        summary: "App {{ $labels.app }} has too many 5xx errors"
+        description: "Further context to help your fix this alert"
+
+```
+
+Your alerting rule may not be perfect first time, for example you may get alerts that did not require any action to resolve them as the threshold was too low. We suggest iterating on your alerting rule to improve your expression or threshold.
+
+### Create a PR with your alerting rule
+
+Create a pull request with your changes to your alerting rules file. Your commit should explain what the alert is and why the threshold value was picked. This is important so future team members have the context they need to confidently change the alerting rule and other teams can learn from your alerting rules.
+
+Slack the [#re-prometheus-support][7] channel with the PR so that it can be reviewed. We will try and merge and deploy your pull request as quickly as possible. We will let you know when your alerting rule is live.
+
+## How to receive alerts
+
+Once Prometheus triggers an alert, it sends this to [Alertmanager][10]. Alertmanager is then responsible for forwarding alerts to receivers such as [Pagerduty][11] or [Zendesk][12].
+
+Alerts are forwarded to the appropriate team and receiver using the [Alertmanager config file][9] which matches the labels on alerts to decide which team and receiver should be sent the alert.
+
+If you have not yet set up a receiver or would like to set up additional receivers then please contact us in [Slack][7] for help doing so.
+
+
+[0]: https://prometheus.io/
+[1]: https://prom-2.monitoring.gds-reliability.engineering
+[2]: https://github.com/alphagov/prometheus-aws-configuration-beta/tree/master/terraform/projects/app-ecs-services/config/alerts
+[3]: https://github.com/alphagov/prometheus-aws-configuration-beta/
+[4]: https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/
+[5]: https://prometheus.io/docs/prometheus/latest/querying/basics/
+[6]: https://gds-way.cloudapps.digital/standards/alerting.html#alerting
+[7]: https://gds.slack.com/messages/CAF5H4N4Q
+[8]: https://github.com/alphagov/paas-metric-exporter
+[9]: https://github.com/alphagov/prometheus-aws-configuration-beta/blob/master/terraform/projects/app-ecs-services/templates/alertmanager.tpl
+[10]: https://prometheus.io/docs/alerting/alertmanager/
+[11]: https://www.pagerduty.com/
+[12]: https://www.zendesk.com/

--- a/source/manuals/alerting-with-prometheus-for-paas.html.md.erb
+++ b/source/manuals/alerting-with-prometheus-for-paas.html.md.erb
@@ -40,7 +40,7 @@ An alerting rule file will look something like this:
   groups:
 - name: Your team name
   rules:
-  - alert: RequestsExcess5xx
+  - alert: TeamName_RequestsExcess5xx
     expr: rate(requests{org="your-paas-org" job="yourteam-metric-exporter", exported_space="prod", status_range="5xx"}[5m]) > 1
     for: 120s
     labels:

--- a/source/manuals/alerting-with-prometheus-for-paas.html.md.erb
+++ b/source/manuals/alerting-with-prometheus-for-paas.html.md.erb
@@ -6,7 +6,7 @@ title: How to create or edit alerts with Prometheus
 
 ## Choosing alerts
 
-When deciding what alerts you want to receive, consider: 
+When deciding what alerts you want to receive, consider:
 
 - reading the [Alerting principles][6] in the GDS Way
 - looking at [existing alerting rules][2] used by other GDS teams
@@ -32,7 +32,7 @@ Alerting rules are defined in YAML format in a config file in the [prometheus-aw
 
 Alerting rules should be prefixed with your team name, for example `registers_RequestsExcess5xx` or `DGU_HighDiskUsage`. This makes your alert easier to identify.
 
-You must add a `product` label to your alerting rule under `labels` so if the alert is triggered, Prometheus will alert the correct team. 
+You must add a `product` label to your alerting rule under `labels` so if the alert is triggered, Prometheus will alert the correct team.
 
 The alerting rule file should look something like this:
 

--- a/source/manuals/alerting-with-prometheus-for-paas.html.md.erb
+++ b/source/manuals/alerting-with-prometheus-for-paas.html.md.erb
@@ -14,7 +14,7 @@ When deciding what alerts you want to receive, consider:
 
 ## How to create or update alerting rules
 
-You should first read [Prometheus' alerting rules documentation][4] to understand how the alerts work. 
+You should first read [Prometheus' alerting rules documentation][4] to understand how alerting works.
 
 You will also need to understand how to write an expression in [PromQL][5] for your alerting rules.
 

--- a/source/manuals/alerting-with-prometheus-for-paas.html.md.erb
+++ b/source/manuals/alerting-with-prometheus-for-paas.html.md.erb
@@ -24,7 +24,7 @@ Use the [Prometheus dashboard][1] to experiment writing your alert as a [PromQL]
 
 The expression should generate some metrics which could be used in the alert, so no metrics will mean that the alert will not fire.
 
-Your expression must contain a `job` label that points at your team's metrics so that you don't accidently include metrics from other teams.
+Your expression must contain an `org` label, which refers to your PaaS organisation, to ensure you don't accidently include metrics from other teams. Whilst the `job` label, which defines the source of the metrics, may be sufficient for this it should not be used without `org` as it is not guaranteed to always be unique to your team.
 
 Make sure to only include timeseries for the PaaS space you wish to alert on (e.g. production). For timeseries produced by application client libraries, this can be done by including `space="production"`. For timeseries produced by the [paas-metric-exporter][8] this can be done by including `exported_space="production"`.
 
@@ -43,7 +43,7 @@ An alerting rule file will look something like this:
 - name: Your team name
   rules:
   - alert: RequestsExcess5xx
-    expr: rate(requests{job="yourteam-metric-exporter", exported_space="prod", status_range="5xx"}[5m]) > 1
+    expr: rate(requests{org="your-paas-org" job="yourteam-metric-exporter", exported_space="prod", status_range="5xx"}[5m]) > 1
     for: 120s
     labels:
         product: "yourteam"

--- a/source/manuals/alerting-with-prometheus-for-paas.html.md.erb
+++ b/source/manuals/alerting-with-prometheus-for-paas.html.md.erb
@@ -4,37 +4,37 @@ title: How to create or edit alerts with Prometheus
 
 # <%= current_page.data.title %>
 
-## What you should be alerting on
+## Choosing alerts
 
-When deciding on what your service should be alerting on, you could use the following:
+When deciding what alerts you want to receive, consider: 
 
-- [Alerting principles][6] in the GDS Way
-- Look at [existing alerting rules][2] used by other GDS teams
-- Talk to us for advice using the [#re-prometheus-support][7] Slack channel
+- reading the[Alerting principles][6] in the GDS Way
+- looking at [existing alerting rules][2] used by other GDS teams
+- talking to us for advice using the [#re-prometheus-support][7] Slack channel
 
 ## How to create or update alerting rules
 
-You should first read the [Prometheus alerting rules documentation][4] to understand the alerting concepts.
+You should first read [Prometheus' alerting rules documentation][4] to understand how the alerts work. 
 
-You will also need to understand how to write an expression in [PromQL][5] for your alerting rule.
+You will also need to understand how to write an expression in [PromQL][5] for your alerting rules.
 
 ### Writing your alerting rule PromQL expression
 
 Use the [Prometheus dashboard][1] to experiment writing your alert as a [PromQL][5] expression.
 
-Your expression must contain an `org` label, which refers to your PaaS organisation, to ensure you don't accidently include metrics from other teams. Whilst the `job` label, which defines the source of the metrics, may be sufficient for this it should not be used without `org` as it is not guaranteed to always be unique to your team.
+Your expression must contain an `org` label, which refers to your PaaS organisation. This makes you sure it only uses metrics from your job. Although you can use the `job` label for this, it is not guaranteed to be unique to your team.
 
-Make sure to only include timeseries for the PaaS space you wish to alert on (e.g. production). For timeseries produced by application client libraries, this can be done by including `space="production"`. For timeseries produced by the [paas-metric-exporter][8] this can be done by including `exported_space="production"`.
+You should only include timeseries for the PaaS space you wish to alert on, for example production. For timeseries produced by application client libraries, include `space="production"`. For timeseries produced by the [paas-metric-exporter][8] include `exported_space="production"`.
 
 ### Create the alerting rule
 
 Alerting rules are defined in YAML format in a config file in the [prometheus-aws-configuration-beta][2] repository. Each product team should use their own file for their alerting rules.
 
-Alerting rules should be prefixed with your team name, e.g. `registers_RequestsExcess5xx`, `DGU_HighDiskUsage`, to make your alert easier to identify.
+Alerting rules should be prefixed with your team name, for example `registers_RequestsExcess5xx` or `DGU_HighDiskUsage`. This makes your alert easier to identify.
 
-You must add a `product` label to your alerting rule under `labels` so if it triggers the correct team is alerted.
+You must add a `product` label to your alerting rule under `labels` so if the alert is triggered, Prometheus will alert the correct team. 
 
-An alerting rule file will look something like this:
+The alerting rule file should look something like this:
 
 ```
   groups:
@@ -51,21 +51,21 @@ An alerting rule file will look something like this:
 
 ```
 
-Your alerting rule may not be perfect first time, for example you may get alerts that did not require any action to resolve them as the threshold was too low. We suggest iterating on your alerting rule to improve your expression or threshold.
+You may have to iterate your alerting rules to make them more useful for your team. For example you may get alerts that did not require any action as the threshold was too low.
 
 ### Create a PR with your alerting rule
 
-Create a pull request with your changes to your alerting rules file. Your commit should explain what the alert is and why the threshold value was picked. This is important so future team members have the context they need to confidently change the alerting rule and other teams can learn from your alerting rules.
+Create a pull request for changes to your alerting rules file. Your commit should explain what the alert is and why you picked the threshold value. This is so future team members have the context they need to confidently change the alerting rule and other teams can learn from your alerting rules.
 
-Slack the [#re-prometheus-support][7] channel with the PR so that it can be reviewed. We will try and merge and deploy your pull request as quickly as possible. We will let you know when your alerting rule is live.
+Share your pull request in the [#re-prometheus-support][7] channel so we can review it. We will try to merge and deploy your pull request as quickly as possible and will let you know when your alerting rule is live.
 
 ## How to receive alerts
 
-Once Prometheus triggers an alert, it sends this to [Alertmanager][10]. Alertmanager is then responsible for forwarding alerts to receivers such as [Pagerduty][11] or [Zendesk][12].
+Once Prometheus triggers an alert, it sends the alert to [Alertmanager][10]. Alertmanager is then responsible for forwarding alerts to receivers such as [Pagerduty][11] or [Zendesk][12].
 
-Alerts are forwarded to the appropriate team and receiver using the [Alertmanager config file][9] which matches the labels on alerts to decide which team and receiver should be sent the alert.
+Alerts are forwarded to the appropriate team and receiver using the [Alertmanager config file][9] which uses the alert labels to direct the alert to the right team and receiver.
 
-If you have not yet set up a receiver or would like to set up additional receivers then please contact us in [Slack][7] for help doing so.
+If you have not yet set up a receiver or would like to set up additional receivers please contact us on [Slack][7].
 
 
 [0]: https://prometheus.io/

--- a/source/manuals/alerting-with-prometheus-for-paas.html.md.erb
+++ b/source/manuals/alerting-with-prometheus-for-paas.html.md.erb
@@ -8,7 +8,7 @@ title: How to create or edit alerts with Prometheus
 
 When deciding what alerts you want to receive, consider: 
 
-- reading the[Alerting principles][6] in the GDS Way
+- reading the [Alerting principles][6] in the GDS Way
 - looking at [existing alerting rules][2] used by other GDS teams
 - talking to us for advice using the [#re-prometheus-support][7] Slack channel
 

--- a/source/manuals/alerting-with-prometheus-for-paas.html.md.erb
+++ b/source/manuals/alerting-with-prometheus-for-paas.html.md.erb
@@ -22,8 +22,6 @@ You will also need to understand how to write an expression in [PromQL][5] for y
 
 Use the [Prometheus dashboard][1] to experiment writing your alert as a [PromQL][5] expression.
 
-The expression should generate some metrics which could be used in the alert, so no metrics will mean that the alert will not fire.
-
 Your expression must contain an `org` label, which refers to your PaaS organisation, to ensure you don't accidently include metrics from other teams. Whilst the `job` label, which defines the source of the metrics, may be sufficient for this it should not be used without `org` as it is not guaranteed to always be unique to your team.
 
 Make sure to only include timeseries for the PaaS space you wish to alert on (e.g. production). For timeseries produced by application client libraries, this can be done by including `space="production"`. For timeseries produced by the [paas-metric-exporter][8] this can be done by including `exported_space="production"`.


### PR DESCRIPTION
https://trello.com/c/cqaglFzy/496-draft-and-publish-documentation-for-how-to-create-and-edit-alerts-using-our-paas-prometheus

First attempt as guidance for teams creating and editing their prometheus alerts.

Note, there was some debate regarding the index page of the reliability eng docs which reference a monitoring platform (https://reliability-engineering.cloudapps.digital/#monitoring) whereas our service is listed as a 'metrics tool' and if this should remain the case.

It might also be worth thinking about if this guidance is easy enough for users to find from the index page.