### PR TITLE
Update instructions on protecting \metrics endpoint for blue-green deployment

### DIFF
--- a/source/manuals/monitor-paas-app-with-prometheus.html.md.erb
+++ b/source/manuals/monitor-paas-app-with-prometheus.html.md.erb
@@ -37,7 +37,25 @@ Create a Prometheus service within your PaaS space and allow it to bind to apps 
   - `cf update-service <cdn-route-service> \
     -c '{"domain": "<custom-domain>", "headers": ["Accept", "Authorization", "<other app header values>"]}'`
 
-Within 5 minutes Prometheus will start scraping your application for metrics, you can validate this by checking [Grafana][].
+Within 10 minutes Prometheus will start scraping your application for metrics, you can validate this by checking [Grafana][].
+
+### IP whitelist your metrics path if using zero downtime plugins or a `blue-green` deployment process
+
+If you're using a zero downtime plugin such as [autopilot][] it is advisable to disable the basic auth on the metrics endpoint and instead protect the metrics endpoint using IP whitelisting in order to avoid gaps in metrics between deployments.
+
+By using the `re-ip-whitelist-service` you will only allow traffic from GDS Prometheis and [GDS Office IPs][].
+
+1. Register the IP whitelist route service as a user-provided service in your PaaS space.
+
+    `cf create-user-provided-service re-ip-whitelist-service -r https://re-ip-whitelist-service.cloudapps.digital`
+
+2. Map the route to the metrics path.
+
+    `cf map-route app-to-protect cloudapps.digital --hostname app-to-protect --path metrics`
+
+3. Register the IP whitelist route service against the metrics path.
+
+    `cf bind-route-service cloudapps.digital re-ip-whitelist-service --hostname app-to-protect --path metrics`
 
 ### App route configuration
 
@@ -47,9 +65,7 @@ For example, some apps may have multiple routes especially if they use custom do
 
 If there are no routes to your app the Prometheus service will default the route to:
 
-`<app-name>.cloudapps.digital`.
-
-Because changes to the first route will only be picked up within 5 minutes it could create gaps to metrics during route changes if you're using a zero downtime plugin such as [autopilot][].
+`<app-name>.cloudapps.digital`
 
 [authorization header and other app headers]: https://docs.cloud.service.gov.uk/deploying_services.html#forwarding-headers
 [autopilot]: https://github.com/contraband/autopilot

--- a/source/manuals/monitor-paas-app-with-prometheus.html.md.erb
+++ b/source/manuals/monitor-paas-app-with-prometheus.html.md.erb
@@ -39,23 +39,41 @@ Create a Prometheus service within your PaaS space and allow it to bind to apps 
 
 Within 10 minutes Prometheus will start scraping your application for metrics, you can validate this by checking [Grafana][].
 
-### IP whitelist your metrics path if using zero downtime plugins or a `blue-green` deployment process
+### When using zero downtime plugins or a `blue-green` deployment process
 
-If you're using a zero downtime plugin such as [autopilot][] it is advisable to disable the basic auth on the metrics endpoint and instead protect the metrics endpoint using IP whitelisting in order to avoid gaps in metrics between deployments.
+#### IP Whitelist your applications metrics endpoint
+
+If you're using a [blue-green deployment process][] with a zero downtime plugin such as [autopilot][] you should disable the basic auth on the metrics endpoint when using the [Ruby gem][] or [Python library][] and instead protect the metrics endpoint using IP whitelisting in order to minimise gaps in metrics between deployments.
 
 By using the `re-ip-whitelist-service` you will only allow traffic from GDS Prometheis and [GDS Office IPs][].
 
-1. Register the IP whitelist route service as a user-provided service in your PaaS space.
+1. Map the route to the metrics path:
+
+  - Update your `manifest.yml`:
+
+```
+      routes:
+      ...
+      - route: app-to-protect.cloudapps.digital/metrics
+```
+
+  - redeploy your app to map the route and path
+
+2. Register the IP whitelist route service as a user-provided service in your PaaS space.
 
     `cf create-user-provided-service re-ip-whitelist-service -r https://re-ip-whitelist-service.cloudapps.digital`
-
-2. Map the route to the metrics path.
-
-    `cf map-route app-to-protect cloudapps.digital --hostname app-to-protect --path metrics`
 
 3. Register the IP whitelist route service against the metrics path.
 
     `cf bind-route-service cloudapps.digital re-ip-whitelist-service --hostname app-to-protect --path metrics`
+
+#### Update your Grafana panel to combine metrics for blue-green deployments
+
+You should update your [Grafana][] panels to combine metrics from different deployment states, for example in order to show the number of healthy instances you can use regex:
+
+    `sum(up{job=~"app-to-protect(-venerable)?"})`
+
+- Note: if you are not using [autopilot][] you will have to substitute `-venerable` to whatever your zero downtime plugin is using during the app renaming.
 
 ### App route configuration
 
@@ -75,3 +93,6 @@ If there are no routes to your app the Prometheus service will default the route
 [#re-prometheus-support Slack channel]: https://gds.slack.com/messages/CAF5H4N4Q/
 [`SpaceAuditor`]: https://docs.cloud.service.gov.uk/orgs_spaces_users.html#space-auditor
 [update your app's manifest.yml]: https://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html#services-block
+[blue-green deployment process]: https://docs.cloudfoundry.org/devguide/deploy-apps/blue-green.html
+[Ruby gem]: https://github.com/alphagov/gds_metrics_ruby#optional-configuration
+[Python library]: https://github.com/alphagov/gds_metrics_python#optional-configuration


### PR DESCRIPTION
## What

In order to avoid gaps in metrics during deployment, the way that `\metrics` endpoints are protected needs to be changed from basic auth to IP whitelisting. This is because during `blue-green` deployments the `GUID` of the app changes and until the `target-grabber` ECS task picks up the latest `GUID` it will be out of sync with the `GUID` used in the basic auth.