### PR TITLE
Ensure service link does not go to live site during local dev

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -4,7 +4,7 @@ host: reliability-engineering.cloudapps.digital
 # Header-related options
 show_govuk_logo: false
 service_name: Reliability Engineering
-service_link: https://reliability-engineering.cloudapps.digital
+service_link: /
 phase: Internal
 
 # Links to show on right-hand-side of header


### PR DESCRIPTION
The service link was hardcoded to the production URL meaning if
you clicked on it during local development you may mistakenly
go to the production site when thinking you are still on your
local version.

I copied this from https://github.com/alphagov/govuk-developer-docs/blob/master/config/tech-docs.yml
and have tested that local dev links work correctly.