### PR TITLE
Make distinction between application and container level metrics

### DIFF
--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -78,16 +78,15 @@ Reliability Engineering provides client libraries which wrap Prometheus's own li
 - guard the `/metrics` API behind HTTP basic auth for GOV.UK PaaS apps
 - ease configuration by using framework-specific things such as [Railties][] or [Dropwizard][] bundles
 
-You can setup GDS metrics for your GOV.UK PaaS app using the Ruby and Java Dropwizard guides on GitHub:
+You can setup application level metrics for your GOV.UK PaaS app using the guides on GitHub:
 
 - [Ruby](https://github.com/alphagov/gds_metrics_ruby)
 - [Java with Dropwizard](https://github.com/alphagov/gds_metrics_dropwizard)
 - [Python](https://github.com/alphagov/gds_metrics_python)
 
-Once you've setup your GOV.UK PaaS app with GDS metrics you can:
+Once you've setup your GOV.UK PaaS app with application metrics you can [monitor your PaaS app with Prometheus](manuals/monitor-paas-app-with-prometheus.html).
 
-* [monitor your PaaS app with Prometheus](manuals/monitor-paas-app-with-prometheus.html)
-* [set up the PaaS metric exporter with Prometheus](manuals/set-up-paas-metric-exporter-with-prometheus.html)
+You can also [set up the PaaS metric exporter with Prometheus](manuals/set-up-paas-metric-exporter-with-prometheus.html) to gather container level metrics for your applications.
 
 When using GDS metrics you can create:
 


### PR DESCRIPTION
We've seen in user research users confused about the difference
between our exporters. This is a small tweak to hopefully make that
less confusing. We could likely make more dramatic changes to the
index page but I am going for speed and least controversy with
this PR in the hopes that it makes small immediate benefit.