### PR TITLE
Add further annonations to our example alert

### DIFF
--- a/source/manuals/alerting-with-prometheus-for-paas.html.md.erb
+++ b/source/manuals/alerting-with-prometheus-for-paas.html.md.erb
@@ -47,8 +47,9 @@ groups:
         product: "yourteam"
     annotations:
         summary: "App {{ $labels.app }} has too many 5xx errors"
-        description: "Further context to help your fix this alert"
-
+        description: "Further context to help your fix this alert. You should include a link to your runbook for this alert if you have one"
+        logs: "A link to any relevant logs, for example https://kibana.logit.io/s/<stack-id>/app/kibana#/discover?_g=()"
+        dashboard: "A link to any relevant monitoring dashboards, for example https://grafana-paas.cloudapps.digital/d/<dashboard-id>"
 ```
 
 You may have to iterate your alerting rules to make them more useful for your team. For example you may get alerts that did not require any action as the threshold was too low.


### PR DESCRIPTION
https://trello.com/c/CYNHxs4S/581-prepare-for-user-research-on-responding-to-alerts

The aim is by adding in these annotations we will encourage
users to do similar when writing their own alerts and therefore
provide sufficient context for anyone needing to investigate an
alert.

We are looking to test this in user research so we wanted to put together some guidance for users to know what a good alert looks like that is actionable and enables quick investigation. This is just a
first pass that hasn't had too much thought.