### PR TITLE
Firebreak: Update guidance to recommend aws-vault for storing AWS keys.

### DIFF
--- a/source/documentation/iaas/access-aws-accounts.md
+++ b/source/documentation/iaas/access-aws-accounts.md
@@ -117,6 +117,26 @@ aws-vault will prompt you for the passphrase that you set above to unlock the
 store (if it hasn't been accessed recently), and then prompt for your MFA
 token.
 
+#### Optional: add some shortcuts to your shell config
+
+If you find the above `aws-vault exec ...` invocation too verbose, you can add
+something like the following to your shell startup script:
+
+```
+for profile in $(awk '/^\[profile / { gsub("]", "", $2); print $2 }' ~/.aws/config); do
+  alias "aws-${profile}"="aws-vault exec ${profile} --"
+done
+```
+
+This sets up an alias for each profile in your `~/.aws/config` so that you can
+then invoke AWS commands as follows:
+
+```
+aws-target-account aws sts get-caller-identity
+aws-target-account terraform plan
+etc...
+```
+
 [Amazon Web Services (AWS)]: https://aws.amazon.com/
 [process called assuming roles]: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-console.html
 [request an AWS account form]: https://gds-request-an-aws-account.cloudapps.digital/


### PR DESCRIPTION
The current guidance is problematic for a number of reasons because it
requires storing AWS keys unencrypted in a file in your home directory.
It's also fiddly to use it with tools other than the AWS CLI.

I've evaluated a few approaches to solving these issues, and determined
that aws-vault is the best option for our needs. This therefore updates
the docs to recommend its usage.

Other avenues explored:

As part of this assessment I looked at several approaches for handling
the keys with the AWS CLI that didn't require storing them in the
credentials file:

* Using `credential_source = Environment` in the profile config. I
  couldn't get this to work - the AWS CLI seems to ignore creds in the
  environment when the `--profile` option is given, adding this setting to
  the config doesn't help.

* Using the `credential_process = ...` [option](https://docs.aws.amazon.com/cli/latest/topic/config-vars.html#sourcing-credentials-from-external-processes). This allows shelling
  out to a process that returns some JSON, which would allow sourcing the
  credentials from something like `pass`. This works for direct access to
  an account, but when used in the source account for an assume-role
  profile, the CLI returned the following error:

  > The source_profile "gds-users" must specify either static credentials
  > or an assume role configuration

Even if these options did work it would still be necessary to add some
scripting to allow an assume-role profile to be easily used with tools
like terraform. It might also be possible to work around some of the
above problems with some scripting, but at this point we start to
reimplement aws-vault... in bash... badly...

Given aws-vault has already solved these issues, and has a smooth
workflow, it makes sense to recommend it.


I've also added an extra commit with some example shell helpers. I'd welcome feedback on whether this is worth adding at all...