### PR TITLE
Move content related to client libraries into set up section

### DIFF
--- a/source/documentation/monitoring-alerts/client-libraries.md
+++ b/source/documentation/monitoring-alerts/client-libraries.md
@@ -1,6 +1,14 @@
 ## Expose app level metrics using client libraries
 
-You can setup GDS metrics for your GOV.UK PaaS app using the Ruby and Java Dropwizard guides on GitHub to instrument:
+We provide client libraries which wrap Prometheus's own libraries to:
+
+- provide an easy metrics choice for GDS teams
+- supply consistent metrics and naming across different runtimes
+- solve problems like, how to get metrics from all worker processes not just one
+- guard the `/metrics` API behind HTTP basic auth for GOV.UK PaaS apps
+- ease configuration by using framework-specific things such as [Railties](https://github.com/rails/rails/tree/master/railties) or [Dropwizard](https://www.dropwizard.io/1.3.2/docs/) bundles
+
+You can setup GDS metrics for your GOV.UK PaaS app using the Ruby, Python and Java Dropwizard guides on GitHub to instrument:
 
 - [Ruby](https://github.com/alphagov/gds_metrics_ruby) in Ruby on Rails or Rack apps
 - [Java with Dropwizard](https://github.com/alphagov/gds_metrics_dropwizard)  in Dropwizard based apps

--- a/source/documentation/monitoring-alerts/client-libraries.md
+++ b/source/documentation/monitoring-alerts/client-libraries.md
@@ -1,6 +1,6 @@
 ## Expose app level metrics using client libraries
 
-We provide client libraries which wrap Prometheus's own libraries to:
+Reliability Engineering provide client libraries which wrap Prometheus's own libraries to:
 
 - provide an easy metrics choice for GDS teams
 - supply consistent metrics and naming across different runtimes

--- a/source/documentation/monitoring-alerts/index.md
+++ b/source/documentation/monitoring-alerts/index.md
@@ -1,12 +1,6 @@
 # Metrics and Alerting
 
-The Reliability Engineering team is running a beta service for GDS using [Prometheus](https://prometheus.io/) for operational metrics, and provides client libraries which wrap Prometheus's own libraries to:
-
-- provide an easy metrics choice for GDS teams
-- supply consistent metrics and naming across different runtimes
-- solve problems like, how to get metrics from all worker processes not just one
-- guard the `/metrics` API behind HTTP basic auth for GOV.UK PaaS apps
-- ease configuration by using framework-specific things such as [Railties](https://github.com/rails/rails/tree/master/railties) or [Dropwizard](https://www.dropwizard.io/1.3.2/docs/) bundles
+The Reliability Engineering team is running a beta service for GDS using [Prometheus](https://prometheus.io/) for operational metrics and alerting.
 
 Contact us on the [#re-prometheus-support][] Slack channel to find out more.
 


### PR DESCRIPTION
This information is not general but instead relates directly
to client libraries so should go in the client library section.

I've kept this simple and just moved the content and haven't spent
time trying to improve the content.