### PR TITLE
Add remove access and delete account sections to AWS guidance

### DIFF
--- a/source/documentation/iaas/delete-aws-accounts.md
+++ b/source/documentation/iaas/delete-aws-accounts.md
@@ -1,5 +1,5 @@
 ## Delete AWS accounts
 
-When your team no longer requires an AWS account, contact Reliability Engineering using the [#Reliability-Eng Slack Channel]().
+When your team no longer requires an AWS account, contact Reliability Engineering using the [#Reliability-Eng Slack Channel](https://gds.slack.com/messages/CAD6NP598/convo/CAD6NP598-1540294660.000100/).
 
 GDS teams are responsible for managing their own leavers’ process.

--- a/source/documentation/iaas/delete-aws-accounts.md
+++ b/source/documentation/iaas/delete-aws-accounts.md
@@ -1,5 +1,5 @@
 ## Delete AWS accounts
 
-When your team no longer requires an AWS account, contact Reliability Engineering using the [#Reliability-Eng Slack Channel](https://gds.slack.com/messages/CAD6NP598/convo/CAD6NP598-1540294660.000100/).
+When your team no longer requires an AWS account, contact Reliability Engineering using the [#Reliability-eng Slack Channel](https://gds.slack.com/messages/CAD6NP598/convo/CAD6NP598-1540294660.000100/).
 
 GDS teams are responsible for managing their own leavers’ process.

--- a/source/documentation/iaas/delete-aws-accounts.md
+++ b/source/documentation/iaas/delete-aws-accounts.md
@@ -1,0 +1,5 @@
+## Delete AWS accounts
+
+When your team no longer requires an AWS account, contact Reliability Engineering using the [#Reliability-Eng Slack Channel]().
+
+GDS teams are responsible for managing their own leavers’ process.

--- a/source/documentation/iaas/remove-access-to-aws.md
+++ b/source/documentation/iaas/remove-access-to-aws.md
@@ -1,0 +1,9 @@
+## Remove access to AWS accounts
+
+When someone no longer requires access to AWS (for example, because they've left GDS or your team) remove them from the `gds-users` base account using the **Request user removal** section of the:
+
+[Request an AWS account form](https://gds-request-an-aws-account.cloudapps.digital/).
+
+Before you request someone's removal make sure they do not need access to AWS in another team within GDS.
+
+GDS teams are responsible for managing their own leavers’ process.

--- a/source/iaas.html.md.erb
+++ b/source/iaas.html.md.erb
@@ -7,4 +7,5 @@ weight: 5
 <%= partial 'documentation/iaas/access-aws-accounts' %>
 <%= partial 'documentation/iaas/create-aws-accounts' %>
 <%= partial 'documentation/iaas/manage-aws-accounts' %>
+<%= partial 'documentation/iaas/delete-aws-accounts' %>
 <%= partial 'documentation/iaas/remove-access-to-aws' %>

--- a/source/iaas.html.md.erb
+++ b/source/iaas.html.md.erb
@@ -7,3 +7,4 @@ weight: 5
 <%= partial 'documentation/iaas/access-aws-accounts' %>
 <%= partial 'documentation/iaas/create-aws-accounts' %>
 <%= partial 'documentation/iaas/manage-aws-accounts' %>
+<%= partial 'documentation/iaas/remove-access-to-aws' %>


### PR DESCRIPTION
This PR adds two sections to our Amazon Web Services (AWS) guidance.

We have sections about creating an AWS account, accessing and managing them, but not removing access or deleting accounts.

This is an attempt to capture how to remove someone's access from AWS and add a placeholder for how to remove\delete an AWS account.

This is suggested guidance, please review and comment.