### PR TITLE
Add example queries for finding metric names

### DIFF
--- a/source/documentation/monitoring-alerts/create-edit-alerts-using-prometheus.md
+++ b/source/documentation/monitoring-alerts/create-edit-alerts-using-prometheus.md
@@ -12,6 +12,16 @@ You should first read [Prometheus' alerting rules documentation][4] to understan
 
 You will also need to understand how to write an expression in [PromQL][5] for your alerting rules.
 
+### Finding your metrics
+
+Prometheus contains metrics related to other teams that may not be useful to you. If you want to see which metrics are available for your team then the following queries will return a list of metric names that are available for your PaaS organisation or metric exporter.
+
+`sum by(__name__) ({org="<<ORG_NAME>>"})` for example `sum by(__name__) ({org="govuk-notify"})`
+
+`sum by(__name__) ({job="<<EXPORTER_APP_NAME>>"})` for example `sum by(__name__) ({job="notify-paas-postgres-exporter"})`
+
+Unfortunately it is not currently possible to order the results alphabetically.
+
 ### Writing your alerting rule PromQL expression
 
 Use the [Prometheus dashboard][1] to experiment writing your alert as a [PromQL][5] expression.

--- a/source/documentation/monitoring-alerts/create-edit-alerts-using-prometheus.md
+++ b/source/documentation/monitoring-alerts/create-edit-alerts-using-prometheus.md
@@ -14,13 +14,15 @@ You will also need to understand how to write an expression in [PromQL][5] for y
 
 ### Finding your metrics
 
-Prometheus contains metrics related to other teams that may not be useful to you. If you want to see which metrics are available for your team then the following queries will return a list of metric names that are available for your PaaS organisation or metric exporter.
+Prometheus contains metrics related to other teams which may not be relevant to you.
+
+To see your team's available metrics, run the following queries to return a list of metric names available for your PaaS organisation or metric exporter.
 
 `sum by(__name__) ({org="<<ORG_NAME>>"})` for example `sum by(__name__) ({org="govuk-notify"})`
 
 `sum by(__name__) ({job="<<EXPORTER_APP_NAME>>"})` for example `sum by(__name__) ({job="notify-paas-postgres-exporter"})`
 
-Unfortunately it is not currently possible to order the results alphabetically.
+It's not currently possible to order these results alphabetically.
 
 ### Writing your alerting rule PromQL expression
 


### PR DESCRIPTION
We want to make it easier for users to write alerts. This adds a section to the reliability engineering docs on how to return a list of metric names for a given organisation.

https://trello.com/c/8BLu6i6O/609-enable-users-to-check-what-metrics-they-have-available