### PR TITLE
Add an example PromQL query without an alerting threshold

### DIFF
--- a/source/documentation/monitoring-alerts/create-edit-alerts-using-prometheus.md
+++ b/source/documentation/monitoring-alerts/create-edit-alerts-using-prometheus.md
@@ -56,7 +56,7 @@ For new alerts, experiment with different thresholds until you find one that fit
 - metric's patterns
 - Service Level Objective
 
-For new alerts, you may need to experiment with different thresholds until you find one that fits your, chosen type of alert, priorities and metric's patterns
+For new alerts, you may need to experiment with different thresholds until you find one that fits your chosen type of alert, priorities and the patterns of your metric.
  
 ### Create the alerting rule
 
@@ -66,7 +66,7 @@ Alerting rules should be prefixed with your team name, for example `registers_Re
 
 You must add a `product` label to your alerting rule under `labels` so if the alert is triggered, Prometheus will alert the correct team.
 
-You may have to iterate your alerting rules to make them more useful for your team. For example you may get alerts that do not require any action as the threshold is too low.
+You may have to iterate your alerting rules to make them more useful for your team. For example, you may get alerts that do not require any action as the threshold is too low (false positives). 
 
 For more information about creating alerts, see the [prometheus-aws-configuration-beta README][13] for an explanation of each field's meaning and an example alert you can customise.
 

--- a/source/documentation/monitoring-alerts/create-edit-alerts-using-prometheus.md
+++ b/source/documentation/monitoring-alerts/create-edit-alerts-using-prometheus.md
@@ -66,9 +66,9 @@ Alerting rules should be prefixed with your team name, for example `registers_Re
 
 You must add a `product` label to your alerting rule under `labels` so if the alert is triggered, Prometheus will alert the correct team.
 
-For further information on how to create an alert, [see the README in the prometheus-aws-configuration-beta repo][13], which explains what each of the fields means and gives you a base to start from.
+You may have to iterate your alerting rules to make them more useful for your team. For example you may get alerts that do not require any action as the threshold is too low.
 
-You may have to iterate your alerting rules to make them more useful for your team. For example you may get alerts that do not require any action as the threshold is too low (false positives).
+For more information about creating alerts, see the [prometheus-aws-configuration-beta README][13] for an explanation of each field's meaning and an example alert you can customise.
 
 ### Create a PR with your alerting rule
 

--- a/source/documentation/monitoring-alerts/create-edit-alerts-using-prometheus.md
+++ b/source/documentation/monitoring-alerts/create-edit-alerts-using-prometheus.md
@@ -44,6 +44,12 @@ Your expression must contain an `org` label, which refers to your PaaS organisat
 
 You should only include timeseries for the PaaS space you wish to alert on, for example only including production using the `space="production"` label.
 
+### Deciding what your alerting thresholds should be
+
+Above, we discussed that making your query into an alert required adding a threshold. The value of this alerting threshold should be informed by your historical data, its averages and spikes, and your current monitoring system's thresholds for this alert.
+
+If it's a brand new alert then experiment with thresholds until you find one that suits the type of alert, your priority for the alert and your metric's patterns.
+
 ### Create the alerting rule
 
 Alerting rules are defined in YAML format in a config file in the [prometheus-aws-configuration-beta][2] repository. Each product team should use their own file for their alerting rules.

--- a/source/documentation/monitoring-alerts/create-edit-alerts-using-prometheus.md
+++ b/source/documentation/monitoring-alerts/create-edit-alerts-using-prometheus.md
@@ -33,24 +33,27 @@ An example PromQL expression is:
 ```
 rate(requests{org="gds-tech-ops", job="observe-metric-exporter", status_range="5xx"}[5m])
 ```
+The above query means "amoumt of requests with status 5xx within the last 5 minutes for org "gds-tech-ops" and job "observe-metrics-exporter".  
 
-To make it into an alert (that is, something that triggers if the data values are higher or lower than expected), the expression requires a threshold to be compared against:
+A query for an alert that fires when data values are higher or lower than expected would require a threshold to compare against:
 
 ```
 rate(requests{org="gds-tech-ops", job="observe-metric-exporter", status_range="5xx"}[5m]) > 1
 ```
 
-Your expression must contain an `org` label, which refers to your PaaS organisation. This makes you sure it only uses metrics from your team. Although you can use the `job` label for this, it is not guaranteed to be unique to your team.
+Your expression should contain an `org` label, which refers to your PaaS organisation. This ensures you only use the metrics from your team. Although the `job` label may serve the same purpose, it is not guaranteed to be unique to your team.
 
 You should only include timeseries for the PaaS space you wish to alert on, for example only including production using the `space="production"` label.
 
 ### Deciding what your alerting thresholds should be
 
-Above, we discussed that making your query into an alert required adding a threshold. The value of this alerting threshold should be informed by your historical data, its averages and spikes, and your current monitoring system's thresholds for this alert.
+We discussed how we can create a query for alert by adding a threshold. In the first instance, you can determine this alerting threshold by looking at the historical values for this queries.  its averages and spikes, and your current monitoring system's thresholds for this alert.
 
-If it's a brand new alert then experiment with thresholds until you find one that suits the type of alert, your priority for the alert and your metric's patterns.
+If it's a brand new alert then experiment with thresholds until you find one that suits the type of alert, your priority for the alert, your metric's patterns and the Service Level Objective for your service.
 
-### Create the alerting rule
+For new alerts, you may need to experiment with different thresholds until you find one that fits your, chosen type of alert, priorities and metric's patterns
+ 
+### Create The alerting rule
 
 Alerting rules are defined in YAML format in a config file in the [prometheus-aws-configuration-beta][2] repository. Each product team should use their own file for their alerting rules.
 
@@ -60,7 +63,7 @@ You must add a `product` label to your alerting rule under `labels` so if the al
 
 For further information on how to create an alert, [see the README in the prometheus-aws-configuration-beta repo][13], which explains what each of the fields means and gives you a base to start from.
 
-You may have to iterate your alerting rules to make them more useful for your team. For example you may get alerts that do not require any action as the threshold is too low.
+You may have to iterate your alerting rules to make them more useful for your team. For example you may get alerts that do not require any action as the threshold is too low (false positives).
 
 ### Create a PR with your alerting rule
 

--- a/source/documentation/monitoring-alerts/create-edit-alerts-using-prometheus.md
+++ b/source/documentation/monitoring-alerts/create-edit-alerts-using-prometheus.md
@@ -28,6 +28,18 @@ It's not currently possible to order these results alphabetically.
 
 Use the [Prometheus dashboard][1] to experiment writing your alert as a [PromQL][5] expression.
 
+An example PromQL expression is:
+
+```
+rate(requests{org="gds-tech-ops", job="observe-metric-exporter", status_range="5xx"}[5m])
+```
+
+To make it into an alert (that is, something that triggers if the data values are higher or lower than expected), the expression requires a threshold to be compared against:
+
+```
+rate(requests{org="gds-tech-ops", job="observe-metric-exporter", status_range="5xx"}[5m]) > 1
+```
+
 Your expression must contain an `org` label, which refers to your PaaS organisation. This makes you sure it only uses metrics from your team. Although you can use the `job` label for this, it is not guaranteed to be unique to your team.
 
 You should only include timeseries for the PaaS space you wish to alert on, for example only including production using the `space="production"` label.

--- a/source/documentation/monitoring-alerts/create-edit-alerts-using-prometheus.md
+++ b/source/documentation/monitoring-alerts/create-edit-alerts-using-prometheus.md
@@ -52,25 +52,9 @@ Alerting rules should be prefixed with your team name, for example `registers_Re
 
 You must add a `product` label to your alerting rule under `labels` so if the alert is triggered, Prometheus will alert the correct team.
 
-The alerting rule file should look something like this:
+For further information on how to create an alert, [see the README in the prometheus-aws-configuration-beta repo][13], which explains what each of the fields means and gives you a base to start from.
 
-```
-groups:
-- name: Your team name
-  rules:
-  - alert: TeamName_RequestsExcess5xx
-    expr: rate(requests{org="your-paas-org", job="yourteam-metric-exporter", space="prod", status_range="5xx"}[5m]) > 1
-    for: 120s
-    labels:
-        product: "yourteam"
-    annotations:
-        summary: "App {{ $labels.app }} has too many 5xx errors"
-        description: "Further context to help your fix this alert. You should include a link to your runbook for this alert if you have one"
-        logs: "A link to any relevant logs, for example https://kibana.logit.io/s/<stack-id>/app/kibana#/discover?_g=()"
-        dashboard: "A link to any relevant monitoring dashboards, for example https://grafana-paas.cloudapps.digital/d/<dashboard-id>"
-```
-
-You may have to iterate your alerting rules to make them more useful for your team. For example you may get alerts that did not require any action as the threshold was too low.
+You may have to iterate your alerting rules to make them more useful for your team. For example you may get alerts that do not require any action as the threshold is too low.
 
 ### Create a PR with your alerting rule
 
@@ -100,3 +84,4 @@ If you have not yet set up a receiver or would like to set up additional receive
 [10]: https://prometheus.io/docs/alerting/alertmanager/
 [11]: https://www.pagerduty.com/
 [12]: https://www.zendesk.com/
+[13]: https://github.com/alphagov/prometheus-aws-configuration-beta/blob/master/terraform/projects/app-ecs-services/config/alerts/README.md

--- a/source/documentation/monitoring-alerts/create-edit-alerts-using-prometheus.md
+++ b/source/documentation/monitoring-alerts/create-edit-alerts-using-prometheus.md
@@ -33,7 +33,7 @@ An example PromQL expression is:
 ```
 rate(requests{org="gds-tech-ops", job="observe-metric-exporter", status_range="5xx"}[5m])
 ```
-The above query means "amoumt of requests with status 5xx within the last 5 minutes for org "gds-tech-ops" and job "observe-metrics-exporter".  
+The above query means "amount of requests with status 5xx within the last 5 minutes for org `gds-tech-ops` and job `observe-metrics-exporter`.  
 
 To make it into an alert (that is, something that triggers if the data values are higher or lower than expected), the expression requires a threshold to be compared against:
 
@@ -56,8 +56,6 @@ For new alerts, experiment with different thresholds until you find one that fit
 - metric's patterns
 - Service Level Objective
 
-For new alerts, you may need to experiment with different thresholds until you find one that fits your chosen type of alert, priorities and the patterns of your metric.
- 
 ### Create the alerting rule
 
 Alerting rules are defined in YAML format in a config file in the [prometheus-aws-configuration-beta][2] repository. Each product team should use their own file for their alerting rules.

--- a/source/documentation/monitoring-alerts/create-edit-alerts-using-prometheus.md
+++ b/source/documentation/monitoring-alerts/create-edit-alerts-using-prometheus.md
@@ -45,15 +45,20 @@ Your expression should contain an `org` label, which refers to your PaaS organis
 
 You should only include timeseries for the PaaS space you wish to alert on, for example only including production using the `space="production"` label.
 
-### Deciding what your alerting thresholds should be
+### Decide your alerting thresholds
 
-We discussed how we can create a query for alert by adding a threshold. In the first instance, you can determine this alerting threshold by looking at the historical values for this queries.  its averages and spikes, and your current monitoring system's thresholds for this alert.
+Queries need thresholds added to them to make them into alerts. You can work out an alert's threshold value from historical data. To do this, use your current monitoring system's thresholds, averages and spikes for each alert.
 
-If it's a brand new alert then experiment with thresholds until you find one that suits the type of alert, your priority for the alert, your metric's patterns and the Service Level Objective for your service.
+For new alerts, experiment with different thresholds until you find one that fits your:
+
+- chosen type of alert
+- alerting priorities
+- metric's patterns
+- Service Level Objective
 
 For new alerts, you may need to experiment with different thresholds until you find one that fits your, chosen type of alert, priorities and metric's patterns
  
-### Create The alerting rule
+### Create the alerting rule
 
 Alerting rules are defined in YAML format in a config file in the [prometheus-aws-configuration-beta][2] repository. Each product team should use their own file for their alerting rules.
 

--- a/source/documentation/monitoring-alerts/create-edit-alerts-using-prometheus.md
+++ b/source/documentation/monitoring-alerts/create-edit-alerts-using-prometheus.md
@@ -35,7 +35,7 @@ rate(requests{org="gds-tech-ops", job="observe-metric-exporter", status_range="5
 ```
 The above query means "amoumt of requests with status 5xx within the last 5 minutes for org "gds-tech-ops" and job "observe-metrics-exporter".  
 
-A query for an alert that fires when data values are higher or lower than expected would require a threshold to compare against:
+To make it into an alert (that is, something that triggers if the data values are higher or lower than expected), the expression requires a threshold to be compared against:
 
 ```
 rate(requests{org="gds-tech-ops", job="observe-metric-exporter", status_range="5xx"}[5m]) > 1


### PR DESCRIPTION
- We were finding that people were copying and pasting the example query
  in the next section with the threshold, then worrying that it didn't
  return any results.
- This adds an example query with values "org=gds-tech-ops" and
  "job=observe-metric-exporter" such that it will return data without
  users having to substitute their own values in for the time being.
- This explains about alerting thresholds and gives an example with one
  to form the alert.