### PR TITLE
Add PagerDuty licence - contact details for the Autom8 team

### DIFF
--- a/source/documentation/monitoring-alerts/create-edit-alerts-using-prometheus.md
+++ b/source/documentation/monitoring-alerts/create-edit-alerts-using-prometheus.md
@@ -82,6 +82,7 @@ Alerts are forwarded to the appropriate team and receiver using the [Alertmanage
 
 If you have not yet set up a receiver or would like to set up additional receivers use the [#re-prometheus-support Slack channel][7].
 
+If you need additional PagerDuty licences contact the Reliability Engineering Autom8 team using the [#re-autom8 Slack channel](14).
 
 [0]: https://prometheus.io/
 [1]: https://prom-2.monitoring.gds-reliability.engineering
@@ -97,3 +98,4 @@ If you have not yet set up a receiver or would like to set up additional receive
 [11]: https://www.pagerduty.com/
 [12]: https://www.zendesk.com/
 [13]: https://github.com/alphagov/prometheus-aws-configuration-beta/blob/master/terraform/modules/app-ecs-services/config/alerts/README.md
+[14]: https://gds.slack.com/messages/CD1F78YJU/


### PR DESCRIPTION
**Context**
People sometimes need to request additional\multiple PagerDuty licences. At the moment we do not specify who to contact to do this.

**Changes proposed in this pull request**
Add contact details for the Autom8 team so people who need multiple or additional PagerDuty licences know who to contact.

**Guidance to review**
create-edit-alerts-using-prometheus.md 
Section - How to receive alerts



