### PR TITLE
Cross-reference re-team-manual on the reliability-engineering home page

### DIFF
--- a/source/documentation/index.md
+++ b/source/documentation/index.md
@@ -8,8 +8,11 @@ Reliability Engineering provide a shared platform to GDS teams comprising of too
 
 To understand the context for our decisions and guidance refer to the [Service Manual][] and the [GDS Way][].
 
+The Reliability Engineering documentation found on this site is intended to help the rest of GDS find out what Reliability Engineering is and what we're doing. If you're a member of Reliability Engineering or just curious about our team processes and ongoing work then please take a look at our [Team Manual][].
+
 [Logit]: https://logit.io/
 [Prometheus]: https://prometheus.io/
 [PaaS incident process]: https://docs.google.com/document/d/155yrsyhHM9Feh-ucxLzyj7toIb2sMK8KiGVdEFLcyfQ/edit
 [Service Manual]: https://www.gov.uk/service-manual
 [GDS Way]: https://gds-way.cloudapps.digital/#gds-technical-guidance
+[Team Manual]: https://re-team-manual.cloudapps.digital


### PR DESCRIPTION
We have a number of different places for documentation that are unlikely to be
consolidated. In light of this it makes sense to cross-reference where possible
so that documentation need not be repeated again and again and it's possible to
find ~all~ most of the resources if you have found one.

The re-team-manual has an existing reference for the reliability-engineering
docs so this commit balances that out and completes the cross-reference between
those two sites.