### PR TITLE
Upgrade the CF stack to cflinuxfs3 and fix syntax deprecation warning

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -3,4 +3,6 @@ applications:
 - name: reliability-engineering
   memory: 64M
   path: ./build
-  buildpack: staticfile_buildpack
+  buildpacks:
+    - staticfile_buildpack
+  stack: cflinuxfs3


### PR DESCRIPTION
- `cflinuxfs3` is the new version that all apps will move to soon.
- Seeing:
  ```
  Deprecation warning: Use of 'buildpack' attribute in manifest is
  deprecated in favor of 'buildpacks'. Please see
  http://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html#deprecated
  for alternatives and other app manifest deprecations. This feature
  will be removed in the future
  ```
  was annoying.