### PR TITLE
Build PRs on Concourse, not Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,0 @@
-language: ruby
-cache: bundler
-bundler_args: "--without development"
-script: bundle exec middleman build


### PR DESCRIPTION
- This is the next step after building master on Concourse not Travis. To remove Travis entirely.