### PR TITLE
Add documentation into cd (multitenant) concourse

### DIFF
--- a/source/continuous-integration-and-delivery.html.md.erb
+++ b/source/continuous-integration-and-delivery.html.md.erb
@@ -1,0 +1,13 @@
+---
+title: Continuous integration and delivery
+weight: 3
+---
+
+<%= partial 'documentation/continuous-integration-and-delivery/index' %>
+<%= partial 'documentation/continuous-integration-and-delivery/tenancy' %>
+<%= partial 'documentation/continuous-integration-and-delivery/getting-started' %>
+<%= partial 'documentation/continuous-integration-and-delivery/teams' %>
+<%= partial 'documentation/continuous-integration-and-delivery/roles' %>
+<%= partial 'documentation/continuous-integration-and-delivery/services' %>
+<%= partial 'documentation/continuous-integration-and-delivery/secrets' %>
+<%= partial 'documentation/continuous-integration-and-delivery/example-pipelines' %>

--- a/source/continuous-integration-and-delivery.html.md.erb
+++ b/source/continuous-integration-and-delivery.html.md.erb
@@ -10,4 +10,5 @@ weight: 3
 <%= partial 'documentation/continuous-integration-and-delivery/roles' %>
 <%= partial 'documentation/continuous-integration-and-delivery/services' %>
 <%= partial 'documentation/continuous-integration-and-delivery/secrets' %>
+<%= partial 'documentation/continuous-integration-and-delivery/monitoring' %>
 <%= partial 'documentation/continuous-integration-and-delivery/example-pipelines' %>

--- a/source/continuous-integration-and-delivery.html.md.erb
+++ b/source/continuous-integration-and-delivery.html.md.erb
@@ -11,4 +11,4 @@ weight: 3
 <%= partial 'documentation/continuous-integration-and-delivery/services' %>
 <%= partial 'documentation/continuous-integration-and-delivery/secrets' %>
 <%= partial 'documentation/continuous-integration-and-delivery/monitoring' %>
-<%= partial 'documentation/continuous-integration-and-delivery/example-pipelines' %>
+<%= partial 'documentation/continuous-integration-and-delivery/example-pipeline' %>

--- a/source/documentation/continuous-integration-and-delivery/example-pipeline.md
+++ b/source/documentation/continuous-integration-and-delivery/example-pipeline.md
@@ -1,4 +1,4 @@
-## Example pipelines
+## Example pipeline
 
 ### Deploy an application to GOV.UK PaaS
 

--- a/source/documentation/continuous-integration-and-delivery/example-pipelines.md
+++ b/source/documentation/continuous-integration-and-delivery/example-pipelines.md
@@ -1,0 +1,68 @@
+## Example pipelines
+
+### Deploy an application to GOV.UK PaaS
+
+This pipeline clones a public open source git repository, and deploys it to GOV.UK PaaS
+
+#### Requirements
+
+There must be the following variables set:
+
+- `paas-username`
+- `paas-password`
+
+#### Pipeline
+
+<pre><code>---
+resources:
+  - name: my-git-repo
+    type: git
+    source:
+      branch: master
+      uri: https://github.com/alphagov/my-repo.git
+  
+  - name: my-paas-app
+    type: cf
+    source:
+      api: https://api.london.cloud.service.gov.uk
+      organization: my-service-team
+      space: my-space
+      username: ((paas-username))
+      password: ((paas-password))
+
+jobs:
+  - name: test-and-build
+    public: false
+    plan:
+      - get: my-git-repo
+        trigger: true
+  
+      - task: build
+        config:
+          platform: linux
+  
+          image_resource:
+            type: docker-image
+            source:
+              repository: ruby
+              tag: 2.7
+
+          inputs:
+            - name: my-git-repo
+          outputs:
+            - name: my-git-repo
+
+          run:
+            path: sh
+            dir: my-git-repo
+            args:
+              - -exc
+              - |
+                bundle install
+                bundle exec middleman build
+  
+      - put: deploy-to-paas
+        params:
+          manifest: my-git-repo/manifest.yml
+          path: my-git-repo
+</code></pre>

--- a/source/documentation/continuous-integration-and-delivery/getting-started.md
+++ b/source/documentation/continuous-integration-and-delivery/getting-started.md
@@ -1,0 +1,8 @@
+## Getting started with Concourse
+
+[Concourse](https://concourse-ci.org) has comprehensive
+[documentation](https://concourse-ci.org/docs.html) and [interactive
+examples](https://concourse-ci.org/examples.html).
+
+Reliability Engineering run a short "Introduction to Concourse" workshop,
+if you are interested then let us know.

--- a/source/documentation/continuous-integration-and-delivery/index.md
+++ b/source/documentation/continuous-integration-and-delivery/index.md
@@ -7,3 +7,10 @@ for task automation, running tests and status checks against pull-requests, and
 deploying code.
 
 The Reliability Engineering team help you get started with Concourse, and ensure that the infrastructure is available.
+
+## Links
+
+- [CD Concourse](https://cd.gds-reliability.engineering/)
+- [CD Prometheus](https://prom-1.monitoring.cd.gds-reliability.engineering/)
+- [CD Grafana](https://grafana.monitoring.cd.gds-reliability.engineering/)
+- [CD staging concourse](https://cd-staging.gds-reliability.engineering/)

--- a/source/documentation/continuous-integration-and-delivery/index.md
+++ b/source/documentation/continuous-integration-and-delivery/index.md
@@ -1,0 +1,9 @@
+# Continuous Integration and Delivery
+
+The Reliability Engineering team uses [Concourse](https://concourse-ci.org) for testing and deploying code to production.
+
+Concourse is a versatile, open-source, continuous thing-doer which can be used
+for task automation, running tests and status checks against pull-requests, and
+deploying code.
+
+The Reliability Engineering team help you get started with Concourse, and ensure that the infrastructure is available.

--- a/source/documentation/continuous-integration-and-delivery/monitoring.md
+++ b/source/documentation/continuous-integration-and-delivery/monitoring.md
@@ -1,0 +1,19 @@
+## Monitoring
+
+The Reliability Engineering team's Concourse is monitored using:
+
+- [Prometheus](https://prom-1.monitoring.cd.gds-reliability.engineering) - collection of metrics
+- [Grafana](https://grafana.monitoring.cd.gds-reliability.engineering) - alerting and dashboards
+- Splunk - audit logs
+
+Concourse emits metrics which can be queried to get metrics about pipelines.
+
+For example, the following query shows how often the `internal-apps` pipeline is run over a 12 hour period.
+
+<pre><code>sum
+  without (instance, status) (
+    increase(
+      concourse_builds_finished{team="autom8", pipeline="internal-apps"}[12h]
+    )
+  )
+</code></pre>

--- a/source/documentation/continuous-integration-and-delivery/roles.md
+++ b/source/documentation/continuous-integration-and-delivery/roles.md
@@ -1,0 +1,21 @@
+## Roles
+
+Concourse has 5 roles, which are explained in depth
+[in the documentation](https://concourse-ci.org/user-roles.html).
+
+When the Reliability Engineering team configure your Concourse team, you should
+decide which Concourse team role should be configured. The role you choose will
+be allocated to GitHub teams, so that anyone in the GitHub team is given that
+role.
+
+The roles you should choose between are usually:
+
+- member
+- pipeline-operator
+
+Members can manipulate pipelines and update the configuration of pipelines from
+the command line. This role should be used in most cases.
+
+Pipeline-operators can only interact with pipelines, but cannot update their
+configuration. This role should be used where a strict 2-pairs-of-eyes code
+review policy is enforced.

--- a/source/documentation/continuous-integration-and-delivery/secrets.md
+++ b/source/documentation/continuous-integration-and-delivery/secrets.md
@@ -31,7 +31,9 @@ syntax:
         ((github-ssh-key))
 </code></pre>
 
-There are also some convenience variables provided for you:
+For your convenience when writing Concourse pipelines, there are also some
+variables provided for you which are generated automatically and are immutable
+(hence the `readonly_` prefix).
 
 - `readonly_private_bucket_name` - the name of the private AWS S3 bucket
 - `readonly_private_bucket_arn` - the ARN of the private AWS S3 bucket

--- a/source/documentation/continuous-integration-and-delivery/secrets.md
+++ b/source/documentation/continuous-integration-and-delivery/secrets.md
@@ -1,0 +1,57 @@
+## Secrets
+
+The Reliability Engineering Concourse delegates secrets management to AWS
+Systems Manager Parameter Store and Key Management Service.
+
+Secrets can be managed by users with the `member` role using the [GDS
+CLI](https://github.com/alphagov/gds-cli):
+
+```
+gds cd secrets add
+```
+
+and
+
+```
+gds cd secrets remove
+```
+
+Concourse injects secrets into pipelines at runtime using double parentheses
+syntax:
+
+<pre><code>resources:
+  - name: my-repository
+    type: git
+    source:
+      uri: git@github.com:alphagov/my-repository.git
+      branch: master
+
+      # This is a secret
+      private_key: |
+        ((github-ssh-key))
+</code></pre>
+
+There are also some convenience variables provided for you:
+
+- `readonly_private_bucket_name` - the name of the private AWS S3 bucket
+- `readonly_private_bucket_arn` - the ARN of the private AWS S3 bucket
+- `readonly_private_bucket_domain_name` - the domain name of the private AWS S3 bucket
+
+
+- `readonly_public_bucket_name` - the name of the public AWS S3 bucket
+- `readonly_public_bucket_arn` - the ARN of the public AWS S3 bucket
+- `readonly_public_bucket_domain_name` - the domain name of the public AWS S3 bucket
+
+
+- `readonly_private_ecr_repo_name` - the name of the private AWS ECR
+- `readonly_private_ecr_repo_arn` - the ARN of the private AWS ECR
+- `readonly_private_ecr_repo_url` - the URL of the private AWS ECR
+- `readonly_private_ecr_repo_registry_id` - the ID of the private AWS ECR
+
+
+- `readonly_team_name` - the name of the Concourse team
+- `readonly_local_user_password` - the password for a local user of the Concourse team, which is used for updating pipelines
+
+
+- `readonly_secrets_path_prefix` - the secrets path prefix, which is used for managing secrets
+- `readonly_secrets_kms_key_id` - the AWS KMS Key ID, which is used for encrypting secrets at rest

--- a/source/documentation/continuous-integration-and-delivery/services.md
+++ b/source/documentation/continuous-integration-and-delivery/services.md
@@ -3,11 +3,11 @@
 For convenience, the Reliability Engineering team provision the following
 resources for each Concourse team:
 
-- A private AWS S3 bucket
+- A private AWS S3 bucket (publicly readable from the internet)
 - A public AWS S3 bucket
 - A private AWS Elastic Container Registry (ECR)
 
-Which can be accessed only by the individual Concourse team's worker instances.
+which can be accessed only by the individual Concourse team's worker AWS IAM roles.
 
 Each Concourse team's worker instances have a specific AWS IAM role, this
 allows Concourse to assume roles in other AWS accounts, if those accounts have

--- a/source/documentation/continuous-integration-and-delivery/services.md
+++ b/source/documentation/continuous-integration-and-delivery/services.md
@@ -1,0 +1,14 @@
+## Services
+
+For convenience, the Reliability Engineering team provision the following
+resources for each Concourse team:
+
+- A private AWS S3 bucket
+- A public AWS S3 bucket
+- A private AWS Elastic Container Registry (ECR)
+
+Which can be accessed only by the individual Concourse team's worker instances.
+
+Each Concourse team's worker instances have a specific AWS IAM role, this
+allows Concourse to assume roles in other AWS accounts, if those accounts have
+a role which Concourse is permitted to assume.

--- a/source/documentation/continuous-integration-and-delivery/services.md
+++ b/source/documentation/continuous-integration-and-delivery/services.md
@@ -3,9 +3,9 @@
 For convenience, the Reliability Engineering team provision the following
 resources for each Concourse team:
 
-- A private AWS S3 bucket (publicly readable from the internet by anyone)
-- A public AWS S3 bucket
-- A private AWS Elastic Container Registry (ECR)
+- A public AWS S3 bucket (publicly readable from the internet by anyone)
+- A private AWS S3 bucket (readable only by the team's Concourse workers)
+- A private AWS Elastic Container Registry (ECR) (readonly only by the team's Concourse workers)
 
 which can be accessed only by the individual Concourse team's worker AWS IAM roles.
 

--- a/source/documentation/continuous-integration-and-delivery/services.md
+++ b/source/documentation/continuous-integration-and-delivery/services.md
@@ -3,7 +3,7 @@
 For convenience, the Reliability Engineering team provision the following
 resources for each Concourse team:
 
-- A private AWS S3 bucket (publicly readable from the internet)
+- A private AWS S3 bucket (publicly readable from the internet by anyone)
 - A public AWS S3 bucket
 - A private AWS Elastic Container Registry (ECR)
 

--- a/source/documentation/continuous-integration-and-delivery/teams.md
+++ b/source/documentation/continuous-integration-and-delivery/teams.md
@@ -1,0 +1,26 @@
+## Teams
+
+The Reliability Engineering team configured Concourse so that the workloads of
+different teams run on different infrastructure. This design decision ensures
+that:
+
+- the time taken to schedule and run workloads stays predictable
+- the workloads of each team are isolated to separate pools of resources
+
+Teams do not have to represent actual organisational units, and can instead be
+used for fine-grained control over permissions.
+
+For example: a service team could have two teams:
+
+- `service-team-dev`
+- `service-team-deploy`
+
+Where:
+
+- `service-team-dev` is for pull-requests and management of development environments
+- `service-team-deploy` is for deploying trusted code to production
+
+Where:
+
+- `service-team-dev` includes all service team members
+- `service-team-deploy` includes only team members who are trusted to deploy code

--- a/source/documentation/continuous-integration-and-delivery/tenancy.md
+++ b/source/documentation/continuous-integration-and-delivery/tenancy.md
@@ -10,7 +10,7 @@ The Reliability Engineering team's Concourse is multi-tenanted:
   - (unless the user is a member of both teams)
 
 By default, all Concourse workers share the same egress IP addresses, unless configured otherwise.
-If your team needs separate egress IP addresses, then please ask reliability engineering to make the configuration changes.
+If your team needs separate egress IP addresses, then please ask Reliability Engineering to make the configuration changes.
 
 The Reliability Engineering team's Concourse is managed as follows:
 

--- a/source/documentation/continuous-integration-and-delivery/tenancy.md
+++ b/source/documentation/continuous-integration-and-delivery/tenancy.md
@@ -21,6 +21,4 @@ The Reliability Engineering team's Concourse is managed as follows:
 - Users authenticate using GitHub SSO
   - (if you need Google SSO instead of GitHub, ask the Reliability Engineering team)
 
-- Concourse is accessible from:
-  - the GDS network (Whitechapel and the VPN)
-  - the VPN of a vetted supplier building a Cabinet Office service 
+- Concourse is accessible from the GDS network (Whitechapel and the VPN)

--- a/source/documentation/continuous-integration-and-delivery/tenancy.md
+++ b/source/documentation/continuous-integration-and-delivery/tenancy.md
@@ -1,0 +1,26 @@
+## Tenancy model
+
+The Reliability Engineering team's Concourse is multi-tenanted:
+
+- Concourse is configured with many teams
+
+- Each teams workloads run on separate infrastructure
+
+- Users in one team cannot interact with the pipelines of another team
+  - (unless the user is a member of both teams)
+
+By default, all Concourse workers share the same egress IP addresses, unless configured otherwise.
+If your team needs separate egress IP addresses, then please ask reliability engineering to make the configuration changes.
+
+The Reliability Engineering team's Concourse is managed as follows:
+
+- Concourse is configured to delegate secrets management to AWS Systems Manager Parameter Store
+
+- Concourse worker instances are recreated every morning to ensure they have the latest security patches
+
+- Users authenticate using GitHub SSO
+  - (if you need Google SSO instead of GitHub, ask the Reliability Engineering team)
+
+- Concourse is accessible from:
+  - the GDS network (Whitechapel and the VPN)
+  - the VPN of a vetted supplier building a Cabinet Office service 

--- a/source/documentation/index.md
+++ b/source/documentation/index.md
@@ -3,7 +3,7 @@
 Reliability Engineering provide a shared platform to GDS teams comprising of tools to set up and maintain a service by:
 
 * acquiring tools and where appropriate administers them like [Logit][]
-* running off-the-shelf services as internal SaaS such as [Prometheus][]
+* running off-the-shelf services as internal SaaS such as [Prometheus][] and [Concourse][]
 * providing patterns and guidance like the [PaaS incident process][]
 
 To understand the context for our decisions and guidance refer to:
@@ -18,6 +18,7 @@ The Reliability Engineering documentation found on this site is intended to help
 
 [Logit]: https://logit.io/
 [Prometheus]: https://prometheus.io/
+[Concourse]: https://concourse-ci.org/
 [PaaS incident process]: https://docs.google.com/document/d/155yrsyhHM9Feh-ucxLzyj7toIb2sMK8KiGVdEFLcyfQ/edit
 [GDS Technology & Operations Principles]: documentation/strategy-and-principles/re-principles.html
 [Reliability Engineering Strategy]: documentation/strategy-and-principles/re-strategy.html


### PR DESCRIPTION
What
----

Add documentation into how users can use the multi-tenant Concourse deployment.

Why
----

We should write-down tribal knowledge.

How to review
----

Please give me feedback on how do words, and please ask for clarifications where things are confusing.

I would appreciate other helpful example pipelines.

Screenshots
----

![image](https://user-images.githubusercontent.com/1482692/68472027-8198ce80-0217-11ea-8209-2060767fe06a.png)
_Image of the front-page, which now includes a link to the Concourse project homepage_

![image](https://user-images.githubusercontent.com/1482692/68472082-9ecd9d00-0217-11ea-8e22-e0352011e5ab.png)
_Image of the documentation when rendered, using commit 
c0f3725_

Who can review
----

Anyone can review, and it would be appreciated

I would like reviews from @paroxp who has context, and @idavidmcdonald who is a recent multitenant Concourse user from outside TechOps