### PR TITLE
Fix link to PaaS logit documentation

### DIFF
--- a/source/documentation/logging/logit-sending-logs.md
+++ b/source/documentation/logging/logit-sending-logs.md
@@ -49,7 +49,7 @@ TCP ports are assigned on a per-stack basis at stack creation time and will be d
 
 ## Send logs from PaaS to logit
 
-You can [send logs from PaaS to logit](https://docs.cloud.service.gov.uk/monitoring_apps.html#set-up-the-logit-io-log-management-service)
+You can [send logs from PaaS to logit](https://docs.cloud.service.gov.uk/monitoring_apps.html#set-up-the-logit-log-management-service)
 
 ## Ship logs using Amazon S3
 


### PR DESCRIPTION
The heading was renamed from 'Set up the Logit.io log management service' to 'Set up the Logit log management service' in [alphagov/paas-tech-docs#236553e](https://github.com/alphagov/paas-tech-docs/commit/236553e9cf37903e4307aabb0d8790c644ef7b2c#diff-2d06baeb819bb70891f8facf55df6c64R25-L29). This updates the anchor so that the link jumps straight to the right place in the documentation.