### PR TITLE
Add a GitHub section

### DIFF
--- a/source/documentation/github/access-github-alphagov.md
+++ b/source/documentation/github/access-github-alphagov.md
@@ -13,7 +13,7 @@ Once setup is completed, staff can access GDS resources on [GitHub][] or via the
 
 
 [GitHub]: https://github.com/
-[Alphagov]: https://www.github.com/alphagov/
+[Alphagov]: https://github.com/alphagov/
 [Create a GitHub account]: https://github.com/join
 [two-factor authentication]: https://help.github.com/en/github/authenticating-to-github/configuring-two-factor-authentication
 [Github teams]: https://github.com/orgs/alphagov/teams

--- a/source/documentation/github/access-github-alphagov.md
+++ b/source/documentation/github/access-github-alphagov.md
@@ -9,7 +9,7 @@ People joining GDS do not automatically have access to the GDS GitHub organisati
 
 It’s the individual teams’ responsibility to grant that user access to relevant GDS [GitHub teams][]. 
 
-Once setup is completed, staff can access GDS resources on https://github.com or via the command-line.
+Once setup is completed, staff can access GDS resources on [GitHub][] or via the command-line.
 
 
 [GitHub]: https://www.github.com/

--- a/source/documentation/github/access-github-alphagov.md
+++ b/source/documentation/github/access-github-alphagov.md
@@ -14,7 +14,7 @@ Once setup is completed, staff can access GDS resources on [GitHub][] or via the
 
 [GitHub]: https://www.github.com/
 [Alphagov]: https://www.github.com/alphagov/
-[create a new]: https://github.com/join
+[Create a GitHub account]: https://github.com/join
 [two-factor authentication]: https://help.github.com/en/github/authenticating-to-github/configuring-two-factor-authentication
 [Github teams]: https://github.com/orgs/alphagov/teams
 [SSH connection]: https://help.github.com/en/github/authenticating-to-github/connecting-to-github-with-ssh

--- a/source/documentation/github/access-github-alphagov.md
+++ b/source/documentation/github/access-github-alphagov.md
@@ -1,6 +1,10 @@
 ## Access GitHub Alphagov
 
-People joining GDS do not automatically have access to [Alphagov][] on [GitHub][]. To grant access to Alphagov, user needs to [create a new][] or share an existing GitHub username with the team. All users are required to enable [two-form authentication][] on their GitHub accounts.
+People joining GDS do not automatically have access to the GDS GitHub organisation, [alphagov][]. To gain access:
+
+- [Create a GitHub account][GitHub] if you don't have one already. Existing personal accounts are fine to continue using.
+- Enable [two-factor authentication][] on your GitHub account.
+- Give your GitHub username to your team's tech lead, or your nearest technical Senior Management Team member.
 
 
 It’s the individual teams’ responsibility to grant that user access to relevant Alphagov [teams][]. 

--- a/source/documentation/github/access-github-alphagov.md
+++ b/source/documentation/github/access-github-alphagov.md
@@ -15,6 +15,6 @@ Once setup is completed, staff can access GDS resources on https://github.com or
 [GitHub]: https://www.github.com/
 [Alphagov]: https://www.github.com/alphagov/
 [create a new]: https://github.com/join
-[two-form authentication]: https://help.github.com/en/github/authenticating-to-github/configuring-two-factor-authentication
+[two-factor authentication]: https://help.github.com/en/github/authenticating-to-github/configuring-two-factor-authentication
 [teams]: https://github.com/orgs/alphagov/teams
 [SSH connection]: https://help.github.com/en/github/authenticating-to-github/connecting-to-github-with-ssh

--- a/source/documentation/github/access-github-alphagov.md
+++ b/source/documentation/github/access-github-alphagov.md
@@ -1,0 +1,16 @@
+## Access GitHub Alphagov
+
+People joining GDS do not automatically have access to [Alphagov][] on [GitHub][]. To grant access to Alphagov, user needs to [create a new][] or share an existing GitHub username with the team. All users are required to enable [two-form authentication][] on their GitHub accounts.
+
+
+It’s the individual teams’ responsibility to grant that user access to relevant Alphagov [teams][]. 
+
+Once setup is completed, user can access Alphagov resources using the GitHub portal or [SSH connection] (https://help.github.com/en/github/authenticating-to-github/connecting-to-github-with-ssh).
+
+
+[GitHub]: https://www.github.com/
+[Alphagov]: https://www.github.com/alphagov/
+[create a new]: https://github.com/join
+[two-form authentication]: https://help.github.com/en/github/authenticating-to-github/configuring-two-factor-authentication
+[teams]: https://github.com/orgs/alphagov/teams
+[SSH connection]: https://help.github.com/en/github/authenticating-to-github/connecting-to-github-with-ssh

--- a/source/documentation/github/access-github-alphagov.md
+++ b/source/documentation/github/access-github-alphagov.md
@@ -7,7 +7,7 @@ People joining GDS do not automatically have access to the GDS GitHub organisati
 - Give your GitHub username to your team's tech lead, or your nearest technical Senior Management Team member.
 
 
-It’s the individual teams’ responsibility to grant that user access to relevant Alphagov [teams][]. 
+It’s the individual teams’ responsibility to grant that user access to relevant GDS [GitHub teams][]. 
 
 Once setup is completed, user can access Alphagov resources using the GitHub portal or [SSH connection] (https://help.github.com/en/github/authenticating-to-github/connecting-to-github-with-ssh).
 

--- a/source/documentation/github/access-github-alphagov.md
+++ b/source/documentation/github/access-github-alphagov.md
@@ -1,6 +1,6 @@
 ## Access GitHub Alphagov
 
-People joining GDS do not automatically have access to the GDS GitHub organisation, [alphagov][]. To gain access:
+People joining GDS do not automatically have access to the GDS GitHub organisation, [Alphagov][]. To gain access:
 
 - [Create a GitHub account][GitHub] if you don't have one already. Existing personal accounts are fine to continue using.
 - Enable [two-factor authentication][] on your GitHub account.

--- a/source/documentation/github/access-github-alphagov.md
+++ b/source/documentation/github/access-github-alphagov.md
@@ -17,4 +17,3 @@ Once setup is completed, staff can access GDS resources on [GitHub][] or via the
 [Create a GitHub account]: https://github.com/join
 [two-factor authentication]: https://help.github.com/en/github/authenticating-to-github/configuring-two-factor-authentication
 [GitHub teams]: https://github.com/orgs/alphagov/teams
-[SSH connection]: https://help.github.com/en/github/authenticating-to-github/connecting-to-github-with-ssh

--- a/source/documentation/github/access-github-alphagov.md
+++ b/source/documentation/github/access-github-alphagov.md
@@ -16,5 +16,5 @@ Once setup is completed, staff can access GDS resources on https://github.com or
 [Alphagov]: https://www.github.com/alphagov/
 [create a new]: https://github.com/join
 [two-factor authentication]: https://help.github.com/en/github/authenticating-to-github/configuring-two-factor-authentication
-[teams]: https://github.com/orgs/alphagov/teams
+[Github teams]: https://github.com/orgs/alphagov/teams
 [SSH connection]: https://help.github.com/en/github/authenticating-to-github/connecting-to-github-with-ssh

--- a/source/documentation/github/access-github-alphagov.md
+++ b/source/documentation/github/access-github-alphagov.md
@@ -16,5 +16,5 @@ Once setup is completed, staff can access GDS resources on [GitHub][] or via the
 [Alphagov]: https://github.com/alphagov/
 [Create a GitHub account]: https://github.com/join
 [two-factor authentication]: https://help.github.com/en/github/authenticating-to-github/configuring-two-factor-authentication
-[Github teams]: https://github.com/orgs/alphagov/teams
+[GitHub teams]: https://github.com/orgs/alphagov/teams
 [SSH connection]: https://help.github.com/en/github/authenticating-to-github/connecting-to-github-with-ssh

--- a/source/documentation/github/access-github-alphagov.md
+++ b/source/documentation/github/access-github-alphagov.md
@@ -12,7 +12,7 @@ It’s the individual teams’ responsibility to grant that user access to relev
 Once setup is completed, staff can access GDS resources on [GitHub][] or via the command-line.
 
 
-[GitHub]: https://www.github.com/
+[GitHub]: https://github.com/
 [Alphagov]: https://www.github.com/alphagov/
 [Create a GitHub account]: https://github.com/join
 [two-factor authentication]: https://help.github.com/en/github/authenticating-to-github/configuring-two-factor-authentication

--- a/source/documentation/github/access-github-alphagov.md
+++ b/source/documentation/github/access-github-alphagov.md
@@ -9,7 +9,7 @@ People joining GDS do not automatically have access to the GDS GitHub organisati
 
 It’s the individual teams’ responsibility to grant that user access to relevant GDS [GitHub teams][]. 
 
-Once setup is completed, user can access Alphagov resources using the GitHub portal or [SSH connection] (https://help.github.com/en/github/authenticating-to-github/connecting-to-github-with-ssh).
+Once setup is completed, staff can access GDS resources on https://github.com or via the command-line.
 
 
 [GitHub]: https://www.github.com/

--- a/source/documentation/github/access-github-alphagov.md
+++ b/source/documentation/github/access-github-alphagov.md
@@ -2,7 +2,7 @@
 
 People joining GDS do not automatically have access to the GDS GitHub organisation, [Alphagov][]. To gain access:
 
-- [Create a GitHub account][GitHub] if you don't have one already. Existing personal accounts are fine to continue using.
+- [Create a GitHub account][] if you don't have one already. Existing personal accounts are fine to continue using.
 - Enable [two-factor authentication][] on your GitHub account.
 - Give your GitHub username to your team's tech lead, or your nearest technical Senior Management Team member.
 

--- a/source/documentation/github/access-github-support.md
+++ b/source/documentation/github/access-github-support.md
@@ -11,7 +11,7 @@ All authorized users need to use a dedicated [support portal][] to request Enter
 
 It is recommended users will [Sign In][] before submitting any support requests. Users need to create a separate Enterprise Support account as regular GitHub account is not linked with Enterprise Support portal (hosted within a ZenDesk infrastructure).
 
-Alphagov users should use `@digital.cabinet-office.gov.uk` email during the sign up process to ensure your ticket is prioritised. Contributors need to state they are part of Alphagov organisation within their request.
+Alphagov users should use `@digital.cabinet-office.gov.uk` email during the sign up process to ensure their ticket is prioritised. Contributors need to state they are part of Alphagov organisation within their request.
 
 Users can submit a new ticket using a [support request form]. When a request submitted successfully user will receive an email confirmation from GitHub team.
 

--- a/source/documentation/github/access-github-support.md
+++ b/source/documentation/github/access-github-support.md
@@ -1,0 +1,21 @@
+## Access GitHub support
+
+All Alphagov users and external contributors (as long they have access to any Alphagov private repository) can request Enterprise Support directly from the GitHub team as a part of our [Enterprise Cloud][] agreement.
+
+GitHub support team targets an eight-hour response, Monday to Friday (UK time zone).
+
+
+### Request a support
+
+All authorized users need to use a dedicated [support portal][] to request Enterprise Support. 
+
+It is recommended users will [Sign In][] before submitting any support requests. Users need to create a separate Enterprise Support account as regular GitHub account is not linked with Enterprise Support portal (hosted within a ZenDesk infrastructure).
+
+Alphagov users should use `@digital.cabinet-office.gov.uk` email during the sign up process to ensure your ticket is prioritised. Contributors need to state they are part of Alphagov organisation within their request.
+
+Users can submit a new ticket using a [support request form]. When a request submitted successfully user will receive an email confirmation from GitHub team.
+
+[Enterprise Cloud]: https://help.github.com/en/github/working-with-github-support/github-enterprise-cloud-support
+[support portal]: https://enterprise.githubsupport.com/hc/en-us
+[Sign In]: https://enterprise.githubsupport.com/hc/en-us/signin
+[support request form]: https://enterprise.githubsupport.com/hc/en-us/requests/new?github_product=cloud

--- a/source/documentation/github/index.md
+++ b/source/documentation/github/index.md
@@ -1,6 +1,5 @@
 # GitHub and Alphagov
 
-GDS teams use [GitHub](https://www.github.com) as their default repository hosting and versioning service.
+GDS teams use [GitHub](https://github.com) as their default repository hosting and versioning service.
 
 All GDS teams share one GitHub organization called [Alphagov](https://www.github.com/alphagov). Our GitHub organisation is on the [Enterprise Cloud](https://help.github.com/en/github/getting-started-with-github/githubs-products#github-enterprise) plan.
-

--- a/source/documentation/github/index.md
+++ b/source/documentation/github/index.md
@@ -1,0 +1,6 @@
+# GitHub and Alphagov
+
+GDS teams use [GitHub](https://www.github.com) as their default repository hosting and versioning service.
+
+All GDS teams share one GitHub organization called [Alphagov](https://www.github.com/alphagov). Our GitHub organisation is on the [Enterprise Cloud](https://help.github.com/en/github/getting-started-with-github/githubs-products#github-enterprise) plan.
+

--- a/source/documentation/github/remove-github-access.md
+++ b/source/documentation/github/remove-github-access.md
@@ -6,4 +6,4 @@ When someone no longer requires access to [Alphagov][] because they've left GDS,
 
 
 [Alphagov]: https://www.github.com/alphagov/
-[teams]: https://github.com/orgs/alphagov/teams
+[Github teams]: https://github.com/orgs/alphagov/teams

--- a/source/documentation/github/remove-github-access.md
+++ b/source/documentation/github/remove-github-access.md
@@ -5,5 +5,5 @@ When someone moves to another team within GDS individual teams need to remove/ad
 When someone no longer requires access to [Alphagov][] because they've left GDS, individual team needs to remove their GitHub username from Alphagov organisation.
 
 
-[Alphagov]: https://www.github.com/alphagov/
+[Alphagov]: https://github.com/alphagov/
 [Github teams]: https://github.com/orgs/alphagov/teams

--- a/source/documentation/github/remove-github-access.md
+++ b/source/documentation/github/remove-github-access.md
@@ -1,0 +1,9 @@
+## Update and remove access to Alphagov
+
+When someone moves to another team within GDS individual teams need to remove/add user from/to their specific GitHub [teams][].
+
+When someone no longer requires access to [Alphagov][] because they've left GDS, individual team needs to remove their GitHub username from Alphagov organisation.
+
+
+[Alphagov]: https://www.github.com/alphagov/
+[teams]: https://github.com/orgs/alphagov/teams

--- a/source/documentation/github/remove-github-access.md
+++ b/source/documentation/github/remove-github-access.md
@@ -1,6 +1,6 @@
 ## Update and remove access to Alphagov
 
-When someone moves to another team within GDS individual teams need to remove/add user from/to their specific GitHub [teams][].
+When someone moves to another team within GDS individual teams need to remove/add user from/to their specific GDS [GitHub teams][].
 
 When someone no longer requires access to [Alphagov][] because they've left GDS, individual team needs to remove their GitHub username from Alphagov organisation.
 

--- a/source/github.html.md.erb
+++ b/source/github.html.md.erb
@@ -1,0 +1,10 @@
+---
+title: GitHub and Alphagov
+weight: 6
+---
+
+<%= partial 'documentation/github/index' %>
+<%= partial 'documentation/github/access-github-alphagov' %>
+<%= partial 'documentation/github/access-github-support' %>
+<%= partial 'documentation/github/remove-github-access' %>
+


### PR DESCRIPTION
This is to add a section around GitHub, our Alphagov organisation and support options available with our current licensing.