### PR TITLE
Add accessibility statement for internal documentation

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -11,6 +11,8 @@ phase: INTERNAL
 header_links:
   Documentation: /
   GitHub: https://github.com/alphagov/reliability-engineering
+footer_links:
+  Reliability Engineering Team Manual Accessibility: /accessibility.html
 
 # Enables search functionality. This indexes pages only and is not recommended for single-page sites.
 enable_search: true

--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -12,7 +12,7 @@ header_links:
   Documentation: /
   GitHub: https://github.com/alphagov/reliability-engineering
 footer_links:
-  Reliability Engineering Team Manual Accessibility: /accessibility.html
+  Reliability Engineering Internal Docs Accessibility: /accessibility.html
 
 # Enables search functionality. This indexes pages only and is not recommended for single-page sites.
 enable_search: true

--- a/source/accessibility.html.md.erb
+++ b/source/accessibility.html.md.erb
@@ -1,0 +1,99 @@
+---
+title: Accessibility statement for Reliability Engineering internal documentation
+last_reviewed_on: 2020-09-21
+review_in: 6 months
+hide_in_navigation: true
+---
+
+# Accessibility statement for Reliability Engineering internal documentation
+
+This accessibility statement applies to the Reliability Engineering internal documentation at [https://reliability-engineering.cloudapps.digital/](https://reliability-engineering.cloudapps.digital/).
+
+This website is run by the Reliability Engineering team at the Government Digital Service (GDS). We want as many people as possible to be able to use this website. For example, that means you should be able to:
+
++ change colours, contrast levels and fonts
++ zoom in up to 300% without problems
++ navigate most of the website using just a keyboard
++ navigate most of the website using speech recognition software
++ listen to most of the website using a screen reader (including the most recent versions of JAWS, NVDA and VoiceOver)
+
+We’ve also made the website text as simple as possible to understand.
+
+[AbilityNet](https://mcmw.abilitynet.org.uk/) has advice on making your device easier to use if you have a disability.
+
+## How accessible this website is
+
+We know some parts of this website are not fully accessible for the following reasons:
+
+- some links do not clearly explain where they lead, or that they lead to external sites
+- some pages skip heading levels
+- some images do not have good alternative text, or have no alternative text
+- there are issues caused by our Technical Documentation Template
+
+## Feedback and contact information
+
+If you need any part of this service in a different format like large print, audio recording or braille, email [reliability-engineering@digital.cabinet-office.gov.uk](reliability-engineering@digital.cabinet-office.gov.uk).
+
+We’ll consider your request and get back to you within 2 working days.
+
+## Reporting accessibility problems with this website
+
+We’re always looking to improve the accessibility of this website. If you find any problems not listed on this page or think we’re not meeting accessibility requirements, email [reliability-engineering@digital.cabinet-office.gov.uk](reliability-engineering@digital.cabinet-office.gov.uk).
+
+### Enforcement procedure
+
+The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018
+(the ‘accessibility regulations’). If you’re not happy with how we respond to your complaint, [contact the Equality Advisory and Support Service (EASS)](https://www.equalityadvisoryservice.com/).
+
+## Technical information about this website’s accessibility
+
+GDS is committed to making its website accessible, in accordance with the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.
+
+### Compliance status
+
+This website is partially compliant with the [Web Content Accessibility Guidelines version 2.1](https://www.w3.org/TR/WCAG21/) AA standard, due to the non-compliances listed below.
+
+### Non-accessible content
+
+The content listed below is non-accessible for the following reasons.
+
+#### Non-compliance with the accessibility regulations
+
+Some links do not clearly explain where they lead, or that they lead to external sites. This fails [WCAG 2.1 success criteria 2.4.4 Link Purpose (In Context)](https://www.w3.org/TR/UNDERSTANDING-WCAG20/navigation-mechanisms-refs.html).
+
+Some pages have redundant links. This is not a fail, but should be looked at under [WCAG 2.1 success criterion 2.4.4 Link Purpose (In Context)](https://www.w3.org/TR/UNDERSTANDING-WCAG20/navigation-mechanisms-refs.html).
+
+There are some images which contain text, and a text-only alternative is not available. This fails WCAG 2.1 success criterion [1.4.5 (Images of Text)](https://www.w3.org/WAI/WCAG21/quickref/#images-of-text).
+
+There are parts of this documentation that are not accessible because of [issues caused by our Technical Documentation Template](https://tdt-documentation.london.cloudapps.digital/accessibility/#using-the-technical-documentation-template-for-your-own-documentation).
+
+For example, some code examples use a colour that has very low contrast with the background colour, so the code may be difficult to see. This fails [WCAG 2.1 success criterion 1.4.3 - Contrast (Minimum)](https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html).
+
+## How we tested this website
+
+We last tested this website for accessibility issues in August 2020.
+
+We used manual and automated tests to look for issues such as:
+
+- lack of keyboard accessibility
+- link text that’s not descriptive
+- non-unique or non-hierarchical headings
+- italics, bold or block capital formatting
+- inaccessible formatting in general
+- inaccessible language
+- inaccessible diagrams or images
+- lack of colour contrast for text, important graphics and controls
+- images not having meaningful alt text
+- problems when using assistive technologies such as screen readers and screen magnifiers
+
+## What we’re doing to improve accessibility
+
+We plan to fix the accessibility issues in the content by the end of 2020.
+
+We plan to fix the issues with the Technical Documentation Template by the end of 2020.
+
+## Preparation of this accessibility statement
+
+This statement was prepared on 18 September 2020. It was last reviewed on 21 September 2020.
+
+This website was last tested in August 2020. The test was carried out by the technical writing team at GDS. We used the [WAVE Web Accessibility Evaluation Tool](https://wave.webaim.org/) and a checklist we created with the help of the GDS accessibility team. We tested a sample of pages from each section of the site.


### PR DESCRIPTION
### Context
The deadline for publishing an accessibility statement is 23 September 2020. Currently there is not a statement for Reliability Engineering internal docs. 

### Changes proposed in this pull request
Add an accessibility statement for RE internal docs with information from the August 2020 accessibility audit. This is separate to the statement on the tech doc template itself, which is being handled as part of a separate project.