### PR TITLE
Various GitHub leaver-related improvements

### DIFF
--- a/source/documentation/github/access-github-alphagov.md
+++ b/source/documentation/github/access-github-alphagov.md
@@ -4,6 +4,7 @@ People joining GDS do not automatically have access to the GDS GitHub organisati
 
 - [Create a GitHub account][] if you don't have one already. Existing personal accounts are fine to continue using.
 - Enable [two-factor authentication][] on your GitHub account.
+- [Add your @digital.cabinet-office.gov.uk email address to your GitHub account][] so scripts checking for leavers know you still work for us. You do not need to make it the primary address or public.
 - Give your GitHub username to your team's tech lead, or your nearest technical Senior Management Team member.
 
 
@@ -11,9 +12,13 @@ It’s the individual teams’ responsibility to grant that user access to relev
 
 Once setup is completed, staff can access GDS resources on [GitHub][] or via the command-line.
 
+You may [opt to send alphagov notifications to your gov.uk email address].
+
 
 [GitHub]: https://github.com/
 [Alphagov]: https://github.com/alphagov/
 [Create a GitHub account]: https://github.com/join
 [two-factor authentication]: https://help.github.com/en/github/authenticating-to-github/configuring-two-factor-authentication
 [GitHub teams]: https://github.com/orgs/alphagov/teams
+[Add your @digital.cabinet-office.gov.uk email address to your GitHub account]: https://github.com/settings/emails
+[opt to send alphagov notifications to your gov.uk email address]: https://github.com/settings/notifications

--- a/source/documentation/github/access-github-support.md
+++ b/source/documentation/github/access-github-support.md
@@ -5,7 +5,7 @@ All Alphagov users and external contributors (as long they have access to any Al
 GitHub support team targets an eight-hour response, Monday to Friday (UK time zone).
 
 
-### Request a support
+### Request support
 
 All authorized users need to use a dedicated [support portal][] to request Enterprise Support. 
 

--- a/source/documentation/github/remove-github-access.md
+++ b/source/documentation/github/remove-github-access.md
@@ -2,7 +2,7 @@
 
 When someone moves to another team within GDS individual teams need to remove/add user from/to their specific GDS [GitHub teams][].
 
-When someone no longer requires access to [Alphagov][] because they've left GDS, individual team needs to remove their GitHub username from Alphagov organisation.
+When someone no longer requires access to [Alphagov][] because they've left GDS, their team is ultimately responsible for ensuring their GitHub account is removed from the Alphagov organisation.
 
 
 [Alphagov]: https://github.com/alphagov/


### PR DESCRIPTION
Talk about adding official email addreses to GitHub accounts, and adjust
leavers text to account for the fact that we sometimes centrally remove leavers
from GitHub quicker than their team does.