### PR TITLE
Update logit sign-in instructions

### DIFF
--- a/source/documentation/logging/logit-joiners.md
+++ b/source/documentation/logging/logit-joiners.md
@@ -4,12 +4,10 @@ If you do not have a Logit account you can create one by signing into Logit for 
 
 To sign into Logit:
 
-1. Go to [https://dashboard.logit.io/dashboard](https://dashboard.logit.io/dashboard).
-1. Enter your GDS email address in **Business email address**.
-1. *...the password box should automatically disappear*.
+1. Go to [https://dashboard.logit.io/sign-in](https://dashboard.logit.io/sign-in).
+1. Switch to the "Single Sign-on" tab (note: this is currently very light grey text on a white background, so you may struggle to find it)
+1. Enter your "Company Email Address"
 1. Submit the form to complete Google Authentication.
 1. You're now signed into the Government Digital Service Dashboard.
-
-If you use **Log in with Google** on logit.io you will not sign into the GDS Dashboard.
 
 Once your user account is created, you'll need access to your team's logging stacks. Your team's Tech Lead should be a Logit administrator who will add your account.


### PR DESCRIPTION
Logit makes it very difficult to actually sign in to their product.

This updates the instructions we have to follow the new(ish), even more
difficult process for signing in as an enterprise SSO user.